### PR TITLE
feat: F5 runs selected text, grid cell/drag selection (#27, #28)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import AiCommandPalette from "./components/AiCommandPalette";
 import InfoPanel from "./components/InfoPanel";
 import SettingsModal from "./components/SettingsModal";
 import UpdateChecker from "./components/UpdateChecker";
-import { useEditorStore } from "./stores/editorStore";
+import { useEditorStore, getActiveEditorInstance } from "./stores/editorStore";
 import { useConnectionStore } from "./stores/connectionStore";
 import { useQueryStore } from "./stores/queryStore";
 import { useAiStore } from "./stores/aiStore";
@@ -150,6 +150,23 @@ export default function App() {
   }, []);
 
   const handleRunFromToolbar = useCallback(() => {
+    // If the editor has selected text, run only that; otherwise run full content
+    const editor = getActiveEditorInstance();
+    if (editor) {
+      const selection = editor.getSelection();
+      const model = editor.getModel();
+      if (model) {
+        const text =
+          selection && !selection.isEmpty()
+            ? model.getValueInRange(selection)
+            : model.getValue();
+        if (text.trim()) {
+          handleExecute(text.trim());
+          return;
+        }
+      }
+    }
+    // Fallback: use stored tab content
     const tab = useEditorStore.getState().getActiveTab();
     if (tab && tab.content.trim()) {
       handleExecute(tab.content.trim());

--- a/src/components/DataGrid.tsx
+++ b/src/components/DataGrid.tsx
@@ -26,6 +26,11 @@ interface ContextMenu {
   y: number;
 }
 
+interface SelectedCell {
+  rowIdx: number;
+  colIdx: number;
+}
+
 function formatCell(value: CellValue): React.ReactNode {
   if (value === null) {
     return <span className="italic text-muted-foreground/50">NULL</span>;
@@ -92,6 +97,10 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
   // Selection state: set of visible row indices (from tableRows, not original data)
   const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set());
   const lastClickedRow = useRef<number | null>(null);
+  // Single-cell selection (set by double-click, cleared by row click)
+  const [selectedCell, setSelectedCell] = useState<SelectedCell | null>(null);
+  // Drag-select state
+  const isDragging = useRef(false);
 
   // Context menu
   const [contextMenu, setContextMenu] = useState<ContextMenu | null>(null);
@@ -105,6 +114,7 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
   useEffect(() => {
     setColWidths(columns.map(() => 150));
     setSelectedRows(new Set());
+    setSelectedCell(null);
     lastClickedRow.current = null;
   }, [columns]);
 
@@ -229,36 +239,74 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
   // Clear selection when filters/sorting change (visible row indices shift)
   useEffect(() => {
     setSelectedRows(new Set());
+    setSelectedCell(null);
     lastClickedRow.current = null;
   }, [sorting, columnFilters, globalFilter]);
 
-  const handleRowClick = useCallback(
+  const handleRowMouseDown = useCallback(
     (e: React.MouseEvent, visibleIdx: number) => {
-      setSelectedRows((prev) => {
-        const next = new Set(prev);
+      // Clear cell selection on row click
+      setSelectedCell(null);
 
-        if (e.shiftKey && lastClickedRow.current !== null) {
-          // Range select
-          const start = Math.min(lastClickedRow.current, visibleIdx);
-          const end = Math.max(lastClickedRow.current, visibleIdx);
+      if (e.shiftKey && lastClickedRow.current !== null) {
+        // Range select
+        setSelectedRows((prev) => {
+          const next = new Set(prev);
+          const start = Math.min(lastClickedRow.current!, visibleIdx);
+          const end = Math.max(lastClickedRow.current!, visibleIdx);
           for (let i = start; i <= end; i++) {
             next.add(i);
           }
-        } else if (e.ctrlKey || e.metaKey) {
-          // Toggle single row
+          return next;
+        });
+      } else if (e.ctrlKey || e.metaKey) {
+        // Toggle single row
+        setSelectedRows((prev) => {
+          const next = new Set(prev);
           if (next.has(visibleIdx)) {
             next.delete(visibleIdx);
           } else {
             next.add(visibleIdx);
           }
-        } else {
-          // Single select
-          next.clear();
-          next.add(visibleIdx);
-        }
-        return next;
-      });
+          return next;
+        });
+      } else {
+        // Single select + start drag
+        setSelectedRows(new Set([visibleIdx]));
+        isDragging.current = true;
+      }
       lastClickedRow.current = visibleIdx;
+    },
+    [],
+  );
+
+  const handleRowMouseEnter = useCallback(
+    (visibleIdx: number) => {
+      if (!isDragging.current || lastClickedRow.current === null) return;
+      const start = Math.min(lastClickedRow.current, visibleIdx);
+      const end = Math.max(lastClickedRow.current, visibleIdx);
+      const next = new Set<number>();
+      for (let i = start; i <= end; i++) {
+        next.add(i);
+      }
+      setSelectedRows(next);
+    },
+    [],
+  );
+
+  // Stop drag on mouseup anywhere
+  useEffect(() => {
+    const onMouseUp = () => { isDragging.current = false; };
+    document.addEventListener("mouseup", onMouseUp);
+    return () => document.removeEventListener("mouseup", onMouseUp);
+  }, []);
+
+  const handleCellDoubleClick = useCallback(
+    (e: React.MouseEvent, rowIdx: number, colIdx: number) => {
+      e.stopPropagation();
+      // Select single cell, deselect rows
+      setSelectedRows(new Set());
+      setSelectedCell({ rowIdx, colIdx });
     },
     [],
   );
@@ -313,7 +361,16 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
     setSelectedRows(all);
   }, [tableRows.length]);
 
-  // Keyboard: Ctrl+A to select all, Ctrl+C to copy
+  // Copy a single cell value to clipboard
+  const copyCellValue = useCallback(() => {
+    if (!selectedCell) return;
+    const row = tableRows[selectedCell.rowIdx]?.original;
+    if (!row) return;
+    const value = row[selectedCell.colIdx];
+    navigator.clipboard.writeText(cellToString(value));
+  }, [selectedCell, tableRows]);
+
+  // Keyboard: Ctrl+A to select all, Ctrl+C to copy, Escape to deselect cell
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (!parentRef.current?.contains(document.activeElement) &&
@@ -321,16 +378,25 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
 
       if ((e.ctrlKey || e.metaKey) && e.key === "a") {
         e.preventDefault();
+        setSelectedCell(null);
         selectAll();
       }
-      if ((e.ctrlKey || e.metaKey) && e.key === "c" && selectedRows.size > 0) {
-        e.preventDefault();
-        copyAs("tsv");
+      if ((e.ctrlKey || e.metaKey) && e.key === "c") {
+        if (selectedCell) {
+          e.preventDefault();
+          copyCellValue();
+        } else if (selectedRows.size > 0) {
+          e.preventDefault();
+          copyAs("tsv");
+        }
+      }
+      if (e.key === "Escape" && selectedCell) {
+        setSelectedCell(null);
       }
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [selectAll, copyAs, selectedRows.size]);
+  }, [selectAll, copyAs, selectedRows.size, selectedCell, copyCellValue]);
 
   const virtualizer = useVirtualizer({
     count: tableRows.length,
@@ -381,7 +447,12 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
             {filteredCount.toLocaleString()} of {totalRows.toLocaleString()}
           </span>
         )}
-        {selectedRows.size > 0 && (
+        {selectedCell && (
+          <span className="text-[10px] text-muted-foreground ml-auto">
+            Cell selected
+          </span>
+        )}
+        {!selectedCell && selectedRows.size > 0 && (
           <span className="text-[10px] text-muted-foreground ml-auto">
             {selectedRows.size} row{selectedRows.size !== 1 && "s"} selected
           </span>
@@ -493,7 +564,8 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
                     transform: `translateY(${virtualRow.start}px)`,
                     gridTemplateColumns,
                   }}
-                  onClick={(e) => handleRowClick(e, virtualRow.index)}
+                  onMouseDown={(e) => handleRowMouseDown(e, virtualRow.index)}
+                  onMouseEnter={() => handleRowMouseEnter(virtualRow.index)}
                   onContextMenu={(e) => handleContextMenu(e, virtualRow.index)}
                 >
                   {/* Row number */}
@@ -507,14 +579,23 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
                   >
                     {virtualRow.index + 1}
                   </div>
-                  {row.getVisibleCells().map((cell) => (
-                    <div
-                      key={cell.id}
-                      className="truncate border-r border-border px-2 py-1"
-                    >
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </div>
-                  ))}
+                  {row.getVisibleCells().map((cell, cellIdx) => {
+                    const isCellSelected =
+                      selectedCell?.rowIdx === virtualRow.index &&
+                      selectedCell?.colIdx === cellIdx;
+                    return (
+                      <div
+                        key={cell.id}
+                        className={cn(
+                          "truncate border-r border-border px-2 py-1",
+                          isCellSelected && "ring-2 ring-inset ring-primary bg-primary/15",
+                        )}
+                        onDoubleClick={(e) => handleCellDoubleClick(e, virtualRow.index, cellIdx)}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </div>
+                    );
+                  })}
                 </div>
               );
             })}
@@ -523,20 +604,31 @@ export default function DataGrid({ columns, rows }: DataGridProps) {
       </div>
 
       {/* Context menu */}
-      {contextMenu && selectedRows.size > 0 && (
+      {contextMenu && (selectedRows.size > 0 || selectedCell) && (
         <div
           ref={contextRef}
           className="fixed z-50 min-w-52 rounded-md border border-border bg-background py-1 shadow-lg text-xs"
           style={{ left: contextMenu.x, top: contextMenu.y }}
         >
-          <CtxItem icon={Copy} label="Copy" shortcut="Ctrl+C" onClick={() => copyAs("tsv")} />
-          <CtxItem icon={ClipboardList} label="Copy as CSV" onClick={() => copyAs("csv")} />
-          <CtxItem icon={FileJson} label="Copy as JSON" onClick={() => copyAs("json")} />
-          <CtxItem icon={Table2} label="Copy as Markdown" onClick={() => copyAs("markdown")} />
-          <div className="my-1 border-t border-border" />
+          {selectedCell && (
+            <>
+              <CtxItem icon={Copy} label="Copy cell" shortcut="Ctrl+C" onClick={() => { copyCellValue(); setContextMenu(null); }} />
+              <div className="my-1 border-t border-border" />
+            </>
+          )}
+          {selectedRows.size > 0 && (
+            <>
+              <CtxItem icon={Copy} label={selectedCell ? "Copy row(s)" : "Copy"} shortcut={selectedCell ? undefined : "Ctrl+C"} onClick={() => copyAs("tsv")} />
+              <CtxItem icon={ClipboardList} label="Copy as CSV" onClick={() => copyAs("csv")} />
+              <CtxItem icon={FileJson} label="Copy as JSON" onClick={() => copyAs("json")} />
+              <CtxItem icon={Table2} label="Copy as Markdown" onClick={() => copyAs("markdown")} />
+              <div className="my-1 border-t border-border" />
+            </>
+          )}
           <CtxItem
             label={`Select all (${tableRows.length})`}
             onClick={() => {
+              setSelectedCell(null);
               selectAll();
               setContextMenu(null);
             }}

--- a/src/components/SqlEditor.tsx
+++ b/src/components/SqlEditor.tsx
@@ -3,7 +3,7 @@ import Editor, { type OnMount, type BeforeMount } from "@monaco-editor/react";
 import type { editor as monacoEditor } from "monaco-editor";
 import { invoke } from "@tauri-apps/api/core";
 import { useDarkMode } from "../hooks/useDarkMode";
-import { useEditorStore } from "../stores/editorStore";
+import { useEditorStore, setActiveEditorInstance } from "../stores/editorStore";
 import { useConnectionStore } from "../stores/connectionStore";
 import { useSchemaStore } from "../stores/schemaStore";
 import { useAiStore } from "../stores/aiStore";
@@ -89,6 +89,10 @@ export default function SqlEditor({ onExecute, onFormat, overrideTabId, editorRe
       editorRef.current = editor;
       monacoRef.current = monaco;
       if (editorRefOut) editorRefOut.current = editor;
+      setActiveEditorInstance(editor);
+
+      // Clean up the global ref when this editor is disposed
+      editor.onDidDispose(() => setActiveEditorInstance(null));
 
       // Initial validation
       setTimeout(() => runValidation(), 100);

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,7 +1,20 @@
 import { create } from "zustand";
+import type { editor as monacoEditor } from "monaco-editor";
 import type { EditorTab } from "../types/editor";
 
 const STORAGE_KEY = "sqail_tabs";
+
+// Global ref to the active Monaco editor instance — used by the F5 shortcut
+// handler to read selected text without threading refs through the component tree.
+let _activeEditor: monacoEditor.IStandaloneCodeEditor | null = null;
+
+export function setActiveEditorInstance(ed: monacoEditor.IStandaloneCodeEditor | null) {
+  _activeEditor = ed;
+}
+
+export function getActiveEditorInstance(): monacoEditor.IStandaloneCodeEditor | null {
+  return _activeEditor;
+}
 
 function generateId(): string {
   return crypto.randomUUID();


### PR DESCRIPTION
## Summary
- **#27**: F5 and toolbar Run now execute only the selected text in the Monaco editor. If nothing is selected, the full editor content runs (matching the existing Ctrl+Enter behavior).
- **#28**: Results grid interaction improvements:
  - Double-click a cell to select it (ring highlight, Ctrl+C copies that cell's value)
  - Single click selects the row (unchanged)
  - Click-and-drag across rows selects all rows in the drag range
  - Context menu shows "Copy cell" when a cell is selected
  - Escape clears cell selection

## Test plan
- [ ] Select text in editor, press F5 — only selected text should execute
- [ ] Press F5 with no selection — full editor content should execute
- [ ] Ctrl+Enter with selection still works as before
- [ ] Single click a row in results grid — row is selected
- [ ] Double-click a cell — cell gets ring highlight, row deselects
- [ ] Ctrl+C with cell selected — copies just that cell value
- [ ] Click-drag across multiple rows — all dragged rows get selected
- [ ] Right-click with cell selected — "Copy cell" appears in context menu
- [ ] Escape clears cell selection

Closes #27, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)