### PR TITLE
feat: auto-download llama-server sidecar + local inline AI provider (v0.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ On a desktop-class NVIDIA GPU (RTX 4080 Super) the default model hits **~6 ms fi
 
 Feature is **off by default** — you have to flip the toggle. Nothing is downloaded or run until you do.
 
-**v0.5.0 note:** prebuilt `llama-server` binaries for Windows/macOS are not yet bundled with the installer. Either point at an existing OpenAI-compatible local endpoint (Ollama, LM Studio) in the settings, or supply your own `llama-server` build via the `SQAIL_LLAMA_SERVER_PATH` env var. Linux users can run `./scripts/fetch-llama-cpp.sh` to build one with CUDA.
+**Sidecar runtime:** sqail fetches the `llama-server` binary from the official [llama.cpp release](https://github.com/ggml-org/llama.cpp/releases) on first enable — Windows Vulkan, macOS Metal (arm64 / x86_64), Linux Vulkan. Downloaded once into `<app_data>/inline-ai/bin/` and cached. Power users can override with `SQAIL_LLAMA_SERVER_PATH` (e.g. to run a CUDA build).
 
 ## Install
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,15 @@
 
 ## Unreleased
 
+## v0.5.1
+
+### Inline AI
+- Sidecar runtime auto-download: first enable fetches the platform-appropriate `llama-server` (Windows Vulkan, macOS Metal, Linux Vulkan) from the upstream llama.cpp release and caches it under app-data — no manual install step
+- New **Sidecar runtime** row in Settings → Inline AI with status / Download / Delete / cancel
+- `SQAIL_LLAMA_SERVER_PATH` still overrides for power users who want CUDA or a custom build
+- AI assistant palette: new synthetic "Local (Inline AI)" provider entry appears when inline AI is enabled and the sidecar is ready — selects route through the running llama-server
+- Strips wrapping ```sql code fences from SQL-flow responses so local instruct models don't leak markdown into the editor
+
 ## v0.5.0
 
 ### Inline AI completion

--- a/Vibecoding/inline-ai.md
+++ b/Vibecoding/inline-ai.md
@@ -515,13 +515,17 @@ Sized roughly for solo dev work; a focused ~2-week sprint for MVP.
   per platform) are a conscious non-goal for 0.5.0.
 
 ### Follow-ups tracked after 0.5.0
-- F1. Automated runtime download of `llama-server` (mirror `models.rs`
-  shape, `<app_data>/inline-ai/bin/`, platform-appropriate archive
-  from the official llama.cpp release assets).
+- [x] F1. Automated runtime download of `llama-server` — landed post-0.5.0.
+  `src-tauri/src/ai/inline/binaries.rs` mirrors `models.rs`, stages the
+  archive under `<app_data>/inline-ai/bin/`, extracts flattened
+  alongside the exe. Catalog: Windows x64 Vulkan `.zip`, macOS
+  arm64/x64 Metal `.tar.gz`, Linux x64 Vulkan `.tar.gz`, all pinned to
+  llama.cpp `b8815`.
 - F2. Fill in `scripts/fetch-llama-binaries.sh` for Windows / macOS
-  prebuilts and register them under `bundle.externalBin`.
+  prebuilts and register them under `bundle.externalBin` (optional —
+  F1 already solves the Windows UX problem without installer bloat).
 - F3. Extend `release.yml` with a `verify-inline-ai-binaries` step
-  once F1/F2 land, so CI catches missing artefacts before shipping.
+  once F2 lands, so CI catches missing artefacts before shipping.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqail",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.5.1",
+    "sections": [
+      {
+        "title": "Inline AI",
+        "items": [
+          "Sidecar runtime auto-download: first enable fetches the platform-appropriate llama-server (Windows Vulkan, macOS Metal, Linux Vulkan) from the upstream llama.cpp release \u2014 no manual install step",
+          "New Sidecar runtime row in Settings \u2192 Inline AI with status / Download / Delete / cancel",
+          "SQAIL_LLAMA_SERVER_PATH still overrides for power users who want CUDA or a custom build",
+          "AI assistant palette: new synthetic 'Local (Inline AI)' provider entry appears when inline AI is enabled and the sidecar is ready",
+          "Strips wrapping ```sql code fences from SQL-flow responses so local instruct models don't leak markdown into the editor"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.0",
     "sections": [
       {

--- a/sqail.portal/releases.json
+++ b/sqail.portal/releases.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "0.5.1",
+    "sections": [
+      {
+        "title": "Inline AI",
+        "items": [
+          "Sidecar runtime auto-download: first enable fetches the platform-appropriate llama-server (Windows Vulkan, macOS Metal, Linux Vulkan) from the upstream llama.cpp release \u2014 no manual install step",
+          "New Sidecar runtime row in Settings \u2192 Inline AI with status / Download / Delete / cancel",
+          "SQAIL_LLAMA_SERVER_PATH still overrides for power users who want CUDA or a custom build",
+          "AI assistant palette: new synthetic 'Local (Inline AI)' provider entry appears when inline AI is enabled and the sidecar is ready",
+          "Strips wrapping ```sql code fences from SQL-flow responses so local instruct models don't leak markdown into the editor"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.0",
     "sections": [
       {

--- a/sqail.portal/src/lib/constants.ts
+++ b/sqail.portal/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.5.0";
+export const VERSION = "0.5.1";
 export const BUILD_NUMBER = "20260411-1";
 export const GITHUB_URL = "https://github.com/bartbeecoders/sqail";
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4629,13 +4629,14 @@ dependencies = [
 
 [[package]]
 name = "sqail"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bb8",
  "bb8-tiberius",
  "chrono",
  "dirs",
+ "flate2",
  "futures-util",
  "hex",
  "libc",
@@ -4645,6 +4646,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "tar",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4658,6 +4660,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "uuid",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5348,7 +5351,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -7301,6 +7304,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -7316,3 +7336,15 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqail"
-version = "0.5.0"
+version = "0.5.1"
 description = "A lightweight SQL database editor with AI integration"
 authors = ["sqail"]
 license = "MIT"
@@ -41,6 +41,11 @@ tauri-plugin-fs = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
+
+# Archive extraction for the runtime-downloaded llama-server sidecar.
+zip = { version = "2", default-features = false, features = ["deflate"] }
+flate2 = "1"
+tar = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 tiberius = { version = "0.12", default-features = false, features = ["winauth"] }

--- a/src-tauri/src/ai/inline/binaries.rs
+++ b/src-tauri/src/ai/inline/binaries.rs
@@ -1,0 +1,458 @@
+//! Runtime download of the `llama-server` sidecar binary.
+//!
+//! We ship sqail without a bundled `llama-server`. When the user first
+//! enables inline AI, we fetch a platform-appropriate build from the
+//! upstream llama.cpp GitHub release and drop the executable (plus any
+//! shared libraries next to it) into `<app_data>/inline-ai/bin/`. The
+//! sidecar manager then finds it there via the usual resolver chain.
+//!
+//! Default variants (all Q4-fast, broad-compat, no CUDA runtime needed):
+//! * Windows x86_64 → Vulkan build (`.zip`)
+//! * macOS arm64    → Metal build  (`.tar.gz`)
+//! * macOS x86_64   → Metal build  (`.tar.gz`)
+//! * Linux x86_64   → Vulkan build (`.tar.gz`)
+//!
+//! Power users can override by setting `SQAIL_LLAMA_SERVER_PATH` before
+//! launching sqail — the sidecar resolver prefers that.
+
+use std::io::{self, Cursor};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Notify;
+
+/// Upstream release tag. Kept in lockstep with
+/// `scripts/fetch-llama-cpp.sh` so the dev build and the shipped
+/// runtime are speaking the same protocol.
+pub const RELEASE_TAG: &str = "b8815";
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // platform-gated: only one variant is live per host
+enum Archive {
+    Zip,
+    TarGz,
+}
+
+/// One platform entry in the catalog.
+#[derive(Debug, Clone)]
+struct Asset {
+    url: String,
+    archive: Archive,
+    /// Name of the executable inside the archive — used both to verify
+    /// extraction succeeded and to report the final binary path.
+    exe_name: &'static str,
+}
+
+/// Resolve the asset for the *current* host. `None` means no runtime
+/// download is offered — the user can still bring their own via
+/// `SQAIL_LLAMA_SERVER_PATH`.
+fn asset_for_host() -> Option<Asset> {
+    let base = format!(
+        "https://github.com/ggml-org/llama.cpp/releases/download/{RELEASE_TAG}"
+    );
+
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        return Some(Asset {
+            url: format!("{base}/llama-{RELEASE_TAG}-bin-win-vulkan-x64.zip"),
+            archive: Archive::Zip,
+            exe_name: "llama-server.exe",
+        });
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        return Some(Asset {
+            url: format!("{base}/llama-{RELEASE_TAG}-bin-macos-arm64.tar.gz"),
+            archive: Archive::TarGz,
+            exe_name: "llama-server",
+        });
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        return Some(Asset {
+            url: format!("{base}/llama-{RELEASE_TAG}-bin-macos-x64.tar.gz"),
+            archive: Archive::TarGz,
+            exe_name: "llama-server",
+        });
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        return Some(Asset {
+            url: format!("{base}/llama-{RELEASE_TAG}-bin-ubuntu-vulkan-x64.tar.gz"),
+            archive: Archive::TarGz,
+            exe_name: "llama-server",
+        });
+    }
+
+    #[allow(unreachable_code)]
+    {
+        let _ = base;
+        None
+    }
+}
+
+/// Status surface for the frontend. Mirrors the shape of
+/// `ModelListItem` but there's only ever one binary.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BinaryStatus {
+    pub supported: bool,
+    pub installed: bool,
+    pub path: Option<String>,
+    pub url: Option<String>,
+    pub release_tag: &'static str,
+}
+
+/// Progress event payload — emitted as `inline:binary-download-progress`.
+/// Same phase vocabulary as the model downloader so the frontend can
+/// reuse the download-state reducer shape.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgress {
+    pub downloaded: u64,
+    pub total: u64,
+    /// One of: "started" | "progress" | "extracting" | "completed"
+    ///       | "cancelled" | "error".
+    pub phase: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// `<app_data>/inline-ai/bin/` — where the extracted binary + siblings
+/// end up.
+pub fn bin_dir(app_data: &Path) -> PathBuf {
+    app_data.join("inline-ai").join("bin")
+}
+
+fn partial_path(app_data: &Path, asset: &Asset) -> PathBuf {
+    let name = match asset.archive {
+        Archive::Zip => "llama-server.zip.part",
+        Archive::TarGz => "llama-server.tar.gz.part",
+    };
+    bin_dir(app_data).join(name)
+}
+
+/// Expected path of the extracted binary.
+pub fn expected_binary_path(app_data: &Path) -> Option<PathBuf> {
+    asset_for_host().map(|a| bin_dir(app_data).join(a.exe_name))
+}
+
+pub async fn status(app_data: &Path) -> BinaryStatus {
+    let Some(asset) = asset_for_host() else {
+        return BinaryStatus {
+            supported: false,
+            installed: false,
+            path: None,
+            url: None,
+            release_tag: RELEASE_TAG,
+        };
+    };
+
+    let bin_path = bin_dir(app_data).join(asset.exe_name);
+    let installed = fs::metadata(&bin_path)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false);
+
+    BinaryStatus {
+        supported: true,
+        installed,
+        path: installed.then(|| bin_path.to_string_lossy().into_owned()),
+        url: Some(asset.url),
+        release_tag: RELEASE_TAG,
+    }
+}
+
+/// Delete the on-disk binary + any siblings extracted with it. No-op if
+/// the directory is missing.
+pub async fn delete(app_data: &Path) -> Result<(), String> {
+    let dir = bin_dir(app_data);
+    match fs::remove_dir_all(&dir).await {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("failed to delete {}: {e}", dir.display())),
+    }
+}
+
+/// Download + extract the platform-appropriate llama-server. Emits
+/// `inline:binary-download-progress` events throughout. Honours
+/// `cancel.notified()` for early aborts.
+pub async fn download(
+    app: AppHandle,
+    app_data: PathBuf,
+    cancel: Arc<Notify>,
+) -> Result<PathBuf, String> {
+    let asset = asset_for_host().ok_or_else(|| {
+        "Automatic runtime download is not available for this platform. \
+         Set SQAIL_LLAMA_SERVER_PATH to point at your own llama-server binary."
+            .to_string()
+    })?;
+
+    let dir = bin_dir(&app_data);
+    fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("mkdir bin dir: {e}"))?;
+
+    let partial = partial_path(&app_data, &asset);
+    let already_have = match fs::metadata(&partial).await {
+        Ok(m) if m.is_file() => m.len(),
+        _ => 0,
+    };
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60 * 30))
+        .build()
+        .map_err(|e| format!("http client: {e}"))?;
+    let mut req = client.get(&asset.url);
+    if already_have > 0 {
+        req = req.header("Range", format!("bytes={already_have}-"));
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() && status.as_u16() != 206 {
+        let err = format!("http {status}");
+        emit_progress(&app, already_have, 0, "error", Some(&err));
+        return Err(err);
+    }
+
+    let total = resp
+        .headers()
+        .get(reqwest::header::CONTENT_RANGE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.rsplit('/').next())
+        .and_then(|n| n.parse::<u64>().ok())
+        .or_else(|| resp.content_length().map(|cl| cl + already_have))
+        .unwrap_or(0);
+
+    emit_progress(&app, already_have, total, "started", None);
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&partial)
+        .await
+        .map_err(|e| format!("open partial: {e}"))?;
+
+    let mut stream = resp.bytes_stream();
+    let mut downloaded = already_have;
+    let mut last_tick = std::time::Instant::now();
+
+    loop {
+        tokio::select! {
+            _ = cancel.notified() => {
+                emit_progress(&app, downloaded, total, "cancelled", None);
+                return Err("cancelled".into());
+            }
+            chunk = stream.next() => {
+                match chunk {
+                    None => break,
+                    Some(Ok(bytes)) => {
+                        file.write_all(&bytes)
+                            .await
+                            .map_err(|e| format!("write: {e}"))?;
+                        downloaded += bytes.len() as u64;
+                        if last_tick.elapsed() >= Duration::from_millis(200) {
+                            emit_progress(&app, downloaded, total, "progress", None);
+                            last_tick = std::time::Instant::now();
+                        }
+                    }
+                    Some(Err(e)) => {
+                        let err = format!("network: {e}");
+                        emit_progress(&app, downloaded, total, "error", Some(&err));
+                        return Err(err);
+                    }
+                }
+            }
+        }
+    }
+    file.flush().await.map_err(|e| format!("flush: {e}"))?;
+    drop(file);
+
+    emit_progress(&app, downloaded, total, "extracting", None);
+
+    let archive_bytes = fs::read(&partial)
+        .await
+        .map_err(|e| format!("read archive: {e}"))?;
+
+    // Extraction is synchronous — hop onto a blocking thread so we don't
+    // stall the tokio runtime while chugging through ~100 MB of zip.
+    let dir_for_extract = dir.clone();
+    let exe_name = asset.exe_name.to_string();
+    let archive_kind = asset.archive;
+    let extract_result: Result<(), String> = tokio::task::spawn_blocking(move || {
+        match archive_kind {
+            Archive::Zip => extract_zip(&archive_bytes, &dir_for_extract, &exe_name),
+            Archive::TarGz => extract_tar_gz(&archive_bytes, &dir_for_extract, &exe_name),
+        }
+    })
+    .await
+    .map_err(|e| format!("extract join: {e}"))?;
+    extract_result?;
+
+    // Drop the staged archive now that extraction succeeded.
+    let _ = fs::remove_file(&partial).await;
+
+    let bin_path = dir.join(asset.exe_name);
+    if !bin_path.exists() {
+        let err = format!(
+            "extraction finished but {} was not produced",
+            bin_path.display()
+        );
+        emit_progress(&app, downloaded, total, "error", Some(&err));
+        return Err(err);
+    }
+
+    // `chmod +x` on Unix so the spawner can exec it.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&bin_path) {
+            let mut perms = meta.permissions();
+            perms.set_mode(perms.mode() | 0o755);
+            let _ = std::fs::set_permissions(&bin_path, perms);
+        }
+    }
+
+    emit_progress(&app, downloaded, total, "completed", None);
+    Ok(bin_path)
+}
+
+fn emit_progress(
+    app: &AppHandle,
+    downloaded: u64,
+    total: u64,
+    phase: &str,
+    error: Option<&str>,
+) {
+    let _ = app.emit(
+        "inline:binary-download-progress",
+        DownloadProgress {
+            downloaded,
+            total,
+            phase: phase.to_string(),
+            error: error.map(|s| s.to_string()),
+        },
+    );
+}
+
+/// Flatten a zip archive into `dest`. Upstream releases ship
+/// `build/bin/llama-server.exe` with DLLs next to it — we ignore the
+/// leading directories and copy every file under the directory that
+/// contains `exe_name` into `dest` verbatim.
+fn extract_zip(bytes: &[u8], dest: &Path, exe_name: &str) -> Result<(), String> {
+    let reader = Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(reader).map_err(|e| format!("open zip: {e}"))?;
+
+    // First pass — find the entry whose basename matches exe_name so we
+    // know which prefix to keep.
+    let mut keep_prefix: Option<String> = None;
+    for i in 0..archive.len() {
+        let f = archive
+            .by_index(i)
+            .map_err(|e| format!("zip index {i}: {e}"))?;
+        let name = f.name().to_string();
+        if basename(&name).eq_ignore_ascii_case(exe_name) {
+            keep_prefix = Some(
+                name.rsplit_once('/')
+                    .map(|(parent, _)| format!("{parent}/"))
+                    .unwrap_or_default(),
+            );
+            break;
+        }
+    }
+    let prefix = keep_prefix.ok_or_else(|| {
+        format!("archive did not contain an entry named {exe_name}")
+    })?;
+
+    std::fs::create_dir_all(dest).map_err(|e| format!("mkdir dest: {e}"))?;
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| format!("zip index {i}: {e}"))?;
+        let raw_name = entry.name().to_string();
+        if entry.is_dir() {
+            continue;
+        }
+        // Only keep files that live in the exe's directory.
+        let Some(stripped) = raw_name.strip_prefix(&prefix) else {
+            continue;
+        };
+        if stripped.contains('/') {
+            continue;
+        }
+        let out_path = dest.join(stripped);
+        let mut out = std::fs::File::create(&out_path)
+            .map_err(|e| format!("create {}: {e}", out_path.display()))?;
+        io::copy(&mut entry, &mut out).map_err(|e| format!("copy: {e}"))?;
+    }
+    Ok(())
+}
+
+fn extract_tar_gz(bytes: &[u8], dest: &Path, exe_name: &str) -> Result<(), String> {
+    let gz = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(gz);
+
+    std::fs::create_dir_all(dest).map_err(|e| format!("mkdir dest: {e}"))?;
+
+    // We don't know the prefix up front without a first pass — stream
+    // once into memory buffers, then emit. llama.cpp release tarballs
+    // are ~30 MB so this is cheap.
+    let mut pending: Vec<(String, Vec<u8>)> = Vec::new();
+    for entry in archive.entries().map_err(|e| format!("tar entries: {e}"))? {
+        let mut entry = entry.map_err(|e| format!("tar entry: {e}"))?;
+        let header = entry.header();
+        if !header.entry_type().is_file() {
+            continue;
+        }
+        let path = entry
+            .path()
+            .map_err(|e| format!("tar path: {e}"))?
+            .to_string_lossy()
+            .into_owned();
+        let mut buf = Vec::new();
+        io::copy(&mut entry, &mut buf).map_err(|e| format!("tar copy: {e}"))?;
+        pending.push((path, buf));
+    }
+
+    let prefix = pending
+        .iter()
+        .find(|(p, _)| basename(p) == exe_name)
+        .map(|(p, _)| {
+            p.rsplit_once('/')
+                .map(|(parent, _)| format!("{parent}/"))
+                .unwrap_or_default()
+        })
+        .ok_or_else(|| format!("archive did not contain an entry named {exe_name}"))?;
+
+    for (path, body) in pending {
+        let Some(stripped) = path.strip_prefix(&prefix) else {
+            continue;
+        };
+        if stripped.contains('/') {
+            continue;
+        }
+        let out_path = dest.join(stripped);
+        std::fs::write(&out_path, body)
+            .map_err(|e| format!("write {}: {e}", out_path.display()))?;
+    }
+    Ok(())
+}
+
+fn basename(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}

--- a/src-tauri/src/ai/inline/mod.rs
+++ b/src-tauri/src/ai/inline/mod.rs
@@ -10,6 +10,7 @@
 //!
 //! Phase C (FIM completer) will land in `completer.rs` alongside these.
 
+pub mod binaries;
 pub mod completer;
 pub mod fim;
 pub mod models;

--- a/src-tauri/src/ai/inline/sidecar.rs
+++ b/src-tauri/src/ai/inline/sidecar.rs
@@ -23,6 +23,7 @@ use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Instant};
 
+use super::binaries as inline_binaries;
 use super::models::{self, ModelEntry};
 
 const HEALTH_INTERVAL: Duration = Duration::from_secs(5);
@@ -427,6 +428,15 @@ fn resolve_server_bin(app: &AppHandle) -> Option<PathBuf> {
         ] {
             if candidate.exists() {
                 return Some(candidate);
+            }
+        }
+    }
+
+    // Runtime-downloaded binary in <app_data>/inline-ai/bin/.
+    if let Ok(app_data) = app.path().app_data_dir() {
+        if let Some(p) = inline_binaries::expected_binary_path(&app_data) {
+            if p.exists() {
+                return Some(p);
             }
         }
     }

--- a/src-tauri/src/ai/inline/state.rs
+++ b/src-tauri/src/ai/inline/state.rs
@@ -14,6 +14,8 @@ pub struct InlineAiState {
     pub sidecar: Arc<SidecarManager>,
     /// Cancel flags for in-flight model downloads, keyed by model id.
     pub downloads: Mutex<HashMap<String, Arc<Notify>>>,
+    /// Cancel flag for the in-flight sidecar-binary download (if any).
+    pub binary_download: Mutex<Option<Arc<Notify>>>,
     /// Registry of in-flight FIM completion requests.
     pub completions: Arc<CompletionRegistry>,
 }
@@ -23,6 +25,7 @@ impl InlineAiState {
         Self {
             sidecar: Arc::new(SidecarManager::new()),
             downloads: Mutex::new(HashMap::new()),
+            binary_download: Mutex::new(None),
             completions: Arc::new(CompletionRegistry::new()),
         }
     }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,7 +11,8 @@ use tokio::net::TcpStream;
 use tokio_util::compat::TokioAsyncWriteCompatExt;
 
 use crate::ai::client;
-use crate::ai::provider::{AiHistoryEntry, AiProviderConfig};
+use crate::ai::inline::sidecar::SidecarStatus;
+use crate::ai::provider::{AiHistoryEntry, AiProviderConfig, AiProviderType};
 use crate::auth::entra;
 use crate::db::connections::{ConnectionConfig, Driver, MssqlAuthMethod};
 use crate::metadata::{ColumnMetadata, GeneratedMetadata, ObjectMetadata};
@@ -661,8 +662,14 @@ async fn get_default_provider(state: &State<'_, AppState>) -> Result<AiProviderC
         .ok_or_else(|| "No AI provider configured. Add one in AI settings.".to_string())
 }
 
+/// Sentinel id used by the frontend to request the running local inline
+/// AI sidecar as a virtual provider. There is no persisted config for this
+/// id — we synthesize one on the fly from the current sidecar status.
+const INLINE_LOCAL_PROVIDER_ID: &str = "inline-local";
+
 async fn get_provider(state: &State<'_, AppState>, provider_id: Option<String>) -> Result<AiProviderConfig, String> {
     match provider_id {
+        Some(id) if id == INLINE_LOCAL_PROVIDER_ID => build_inline_local_config(state).await,
         Some(id) => {
             let providers = state.ai_providers.lock().await;
             providers
@@ -672,6 +679,30 @@ async fn get_provider(state: &State<'_, AppState>, provider_id: Option<String>) 
                 .ok_or_else(|| format!("AI provider with id '{}' not found.", id))
         }
         None => get_default_provider(state).await,
+    }
+}
+
+async fn build_inline_local_config(
+    state: &State<'_, AppState>,
+) -> Result<AiProviderConfig, String> {
+    match state.inline_ai.sidecar.status().await {
+        SidecarStatus::Ready { model_id, port } => Ok(AiProviderConfig {
+            id: INLINE_LOCAL_PROVIDER_ID.to_string(),
+            name: format!("Local ({model_id})"),
+            // llama-server speaks OpenAI chat completions at /v1. The
+            // LmStudio streamer handles empty api_keys cleanly (no Bearer
+            // header), which matches what llama-server expects.
+            provider: AiProviderType::LmStudio,
+            api_key: String::new(),
+            model: model_id,
+            base_url: Some(format!("http://127.0.0.1:{port}/v1")),
+            is_default: false,
+            accept_invalid_certs: false,
+        }),
+        _ => Err(
+            "Local inline AI sidecar is not running. Enable inline AI and start the sidecar in Settings."
+                .to_string(),
+        ),
     }
 }
 
@@ -1750,10 +1781,11 @@ pub async fn delete_all_metadata(
 // completion commands will land in Phase C.
 
 use crate::ai::inline::{
+    binaries as inline_binaries,
     completer::{start_completion, CompletionRequest},
     fim,
     models as inline_models,
-    sidecar::{SidecarStatus, StartOptions},
+    sidecar::StartOptions,
 };
 
 #[tauri::command]
@@ -1851,6 +1883,60 @@ pub async fn inline_model_delete(
 ) -> Result<(), String> {
     let app_data = app.path().app_data_dir().map_err(|e| e.to_string())?;
     inline_models::delete(&app_data, &model_id).await
+}
+
+// ─── Sidecar binary (llama-server) — runtime download ─────────────────────
+
+#[tauri::command]
+pub async fn inline_binary_status(
+    app: AppHandle,
+) -> Result<inline_binaries::BinaryStatus, String> {
+    let app_data = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    Ok(inline_binaries::status(&app_data).await)
+}
+
+#[tauri::command]
+pub async fn inline_binary_download(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let app_data = app.path().app_data_dir().map_err(|e| e.to_string())?;
+
+    let cancel = {
+        let mut slot = state.inline_ai.binary_download.lock().await;
+        if slot.is_some() {
+            return Err("sidecar binary download already in progress".into());
+        }
+        let notify = Arc::new(tokio::sync::Notify::new());
+        *slot = Some(notify.clone());
+        notify
+    };
+
+    let result = inline_binaries::download(app.clone(), app_data, cancel).await;
+
+    *state.inline_ai.binary_download.lock().await = None;
+
+    result.map(|p| p.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn inline_binary_cancel_download(
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let slot = state.inline_ai.binary_download.lock().await;
+    match slot.as_ref() {
+        Some(notify) => {
+            notify.notify_waiters();
+            Ok(())
+        }
+        None => Err("no active sidecar binary download".into()),
+    }
+}
+
+#[tauri::command]
+pub async fn inline_binary_delete(app: AppHandle) -> Result<(), String> {
+    let app_data = app.path().app_data_dir().map_err(|e| e.to_string())?;
+    inline_binaries::delete(&app_data).await
 }
 
 // ─── Inline AI FIM completion (Phase C) ───────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,10 @@ pub fn run() {
             commands::inline_model_download,
             commands::inline_model_cancel_download,
             commands::inline_model_delete,
+            commands::inline_binary_status,
+            commands::inline_binary_download,
+            commands::inline_binary_cancel_download,
+            commands::inline_binary_delete,
             commands::inline_complete_start,
             commands::inline_complete_cancel,
         ])

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "sqail",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "dev.sqail",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/AiCommandPalette.tsx
+++ b/src/components/AiCommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import {
   Sparkles,
   Loader2,
@@ -12,9 +12,14 @@ import {
 import { useAiStore } from "../stores/aiStore";
 import { useEditorStore } from "../stores/editorStore";
 import { useConnectionStore } from "../stores/connectionStore";
+import { useInlineAiStore } from "../stores/inlineAiStore";
 import { buildSchemaContext } from "../lib/schemaContext";
-import { AI_FLOW_LABELS, AI_PROVIDER_LABELS } from "../types/ai";
-import type { AiFlow, AiHistoryEntry } from "../types/ai";
+import {
+  AI_FLOW_LABELS,
+  AI_PROVIDER_LABELS,
+  INLINE_LOCAL_PROVIDER_ID,
+} from "../types/ai";
+import type { AiFlow, AiHistoryEntry, AiProviderConfig } from "../types/ai";
 import { invoke } from "@tauri-apps/api/core";
 
 const PREFIX_COMMANDS: Record<string, AiFlow> = {
@@ -83,7 +88,35 @@ export default function AiCommandPalette() {
   const activeConn = connections.find((c) => c.id === activeConnectionId);
   const driver = activeConn?.driver ?? "";
 
-  const hasProvider = providers.length > 0;
+  // Expose the running local inline sidecar as a synthetic provider when
+  // inline AI is enabled AND the sidecar is actually Ready. The entry has
+  // no persistent config — the backend recognises its sentinel id and
+  // routes the request straight at `http://127.0.0.1:<port>/v1`.
+  const inlineEnabled = useInlineAiStore((s) => s.enabled);
+  const inlineSidecar = useInlineAiStore((s) => s.sidecar);
+  const inlineModels = useInlineAiStore((s) => s.models);
+  const virtualInlineProvider = useMemo<AiProviderConfig | null>(() => {
+    if (!inlineEnabled) return null;
+    if (inlineSidecar.state !== "ready") return null;
+    const model = inlineModels.find((m) => m.id === inlineSidecar.modelId);
+    const label = model?.displayName ?? inlineSidecar.modelId;
+    return {
+      id: INLINE_LOCAL_PROVIDER_ID,
+      name: `Local (${label})`,
+      provider: "inlineLocal",
+      apiKey: "",
+      model: inlineSidecar.modelId,
+      isDefault: false,
+    };
+  }, [inlineEnabled, inlineSidecar, inlineModels]);
+
+  const displayProviders = useMemo<AiProviderConfig[]>(() => {
+    return virtualInlineProvider
+      ? [...providers, virtualInlineProvider]
+      : providers;
+  }, [providers, virtualInlineProvider]);
+
+  const hasProvider = displayProviders.length > 0;
   const defaultProvider = getDefaultProvider();
 
   // Load providers on mount
@@ -304,9 +337,9 @@ export default function AiCommandPalette() {
             </span>
           )}
           <div className="flex-1" />
-          {providers.length > 0 && (
+          {displayProviders.length > 0 && (
             <ProviderDropdown
-              providers={providers}
+              providers={displayProviders}
               selectedId={selectedProviderId}
               defaultProvider={defaultProvider}
               onSelect={setSelectedProviderId}

--- a/src/components/InlineAiSettingsTab.tsx
+++ b/src/components/InlineAiSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { Download, Play, RotateCcw, Square, Trash2, Loader2 } from "lucide-react";
+import { Download, Play, RotateCcw, Square, Trash2, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
 import { useMemo } from "react";
 
 import { cn } from "../lib/utils";
@@ -8,6 +8,14 @@ import {
   type ModelListItem,
   type DownloadState,
 } from "../stores/inlineAiStore";
+
+/** Shared shape for the model + binary progress bars. */
+interface ProgressSnapshot {
+  downloaded: number;
+  total: number;
+  phase: string;
+  error?: string;
+}
 
 /**
  * Settings tab for the inline-AI (ghost-text) feature. Renders:
@@ -41,9 +49,18 @@ export default function InlineAiSettingsTab() {
           </div>
           <Toggle checked={s.enabled} onChange={() => s.toggleEnabled()} />
         </div>
+        {s.enabled && !s.binary.installed && s.binary.supported && (
+          <BinaryBanner />
+        )}
         {s.enabled && selectedModel && !selectedModel.downloaded && (
           <OnboardingBanner model={selectedModel} />
         )}
+      </section>
+
+      {/* Sidecar runtime (llama-server binary) */}
+      <section>
+        <SectionHeader>Sidecar runtime</SectionHeader>
+        <SidecarRuntimePanel />
       </section>
 
       {/* Sidecar status */}
@@ -222,6 +239,123 @@ function formatTime(epochMs: number): string {
 }
 
 // ── Onboarding ────────────────────────────────────────────────────────────
+
+function BinaryBanner() {
+  const supported = useInlineAiStore((s) => s.binary.supported);
+  const progress = useInlineAiStore((s) => s.binaryDownload);
+  const downloadBinary = useInlineAiStore((s) => s.downloadBinary);
+  const busy =
+    !!progress &&
+    progress.phase !== "completed" &&
+    progress.phase !== "error" &&
+    progress.phase !== "cancelled";
+
+  if (!supported) {
+    return (
+      <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-[11px] text-amber-900 dark:text-amber-200">
+        Runtime download isn't available for this platform yet. Point at your own
+        <code className="mx-1 rounded bg-amber-500/20 px-1 font-mono">llama-server</code>
+        via <code className="mx-1 rounded bg-amber-500/20 px-1 font-mono">SQAIL_LLAMA_SERVER_PATH</code>.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-[11px] font-medium text-amber-900 dark:text-amber-200">
+            The llama-server sidecar binary isn't installed yet.
+          </div>
+          <div className="mt-0.5 text-[11px] text-amber-800/80 dark:text-amber-200/80">
+            Downloads once from the official llama.cpp release — cached locally.
+          </div>
+        </div>
+        <button
+          onClick={() => downloadBinary()}
+          disabled={busy}
+          className="flex shrink-0 items-center gap-1 rounded-md bg-amber-500 px-2.5 py-1 text-[11px] font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+        >
+          {busy ? <Loader2 size={12} className="animate-spin" /> : <Download size={12} />}
+          {busy ? "Downloading" : "Download runtime"}
+        </button>
+      </div>
+      {busy && progress && <ProgressBar state={progress} className="mt-2" />}
+    </div>
+  );
+}
+
+function SidecarRuntimePanel() {
+  const binary = useInlineAiStore((s) => s.binary);
+  const progress = useInlineAiStore((s) => s.binaryDownload);
+  const downloadBinary = useInlineAiStore((s) => s.downloadBinary);
+  const cancelDownload = useInlineAiStore((s) => s.cancelBinaryDownload);
+  const deleteBinary = useInlineAiStore((s) => s.deleteBinary);
+
+  const busy =
+    !!progress &&
+    progress.phase !== "completed" &&
+    progress.phase !== "error" &&
+    progress.phase !== "cancelled";
+
+  if (!binary.supported) {
+    return (
+      <div className="rounded-md border border-border bg-muted/20 p-3 text-[11px] text-muted-foreground">
+        No bundled runtime for this platform. Set
+        <code className="mx-1 rounded bg-muted px-1 font-mono">SQAIL_LLAMA_SERVER_PATH</code>
+        to your own <code className="rounded bg-muted px-1 font-mono">llama-server</code> build.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs">
+          {binary.installed ? (
+            <CheckCircle2 size={13} className="text-emerald-500" />
+          ) : (
+            <AlertTriangle size={13} className="text-amber-500" />
+          )}
+          <div>
+            <div className="font-medium">
+              {binary.installed ? "Installed" : "Not installed"}
+              {binary.releaseTag && (
+                <span className="ml-1 text-[10px] font-normal text-muted-foreground">
+                  {binary.releaseTag}
+                </span>
+              )}
+            </div>
+            {binary.installed && binary.path && (
+              <div className="truncate text-[10px] text-muted-foreground" title={binary.path}>
+                {binary.path}
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 gap-1">
+          {binary.installed ? (
+            <SmallBtn onClick={() => deleteBinary()} variant="danger">
+              <Trash2 size={11} /> Delete
+            </SmallBtn>
+          ) : busy ? (
+            <SmallBtn onClick={() => cancelDownload()} variant="danger">
+              <Square size={11} /> Cancel
+            </SmallBtn>
+          ) : (
+            <SmallBtn onClick={() => downloadBinary()}>
+              <Download size={11} /> Download
+            </SmallBtn>
+          )}
+        </div>
+      </div>
+      {busy && progress && <ProgressBar state={progress} />}
+      {!busy && progress && progress.phase === "error" && (
+        <div className="text-[10px] text-destructive">{progress.error}</div>
+      )}
+    </div>
+  );
+}
 
 function OnboardingBanner({ model }: { model: ModelListItem }) {
   const progress = useInlineAiStore((s) => s.downloads[model.id]);
@@ -464,7 +598,7 @@ function ProgressBar({
   state,
   className,
 }: {
-  state: DownloadState;
+  state: ProgressSnapshot;
   className?: string;
 }) {
   const pct =

--- a/src/hooks/useInlineAiLifecycle.ts
+++ b/src/hooks/useInlineAiLifecycle.ts
@@ -5,6 +5,7 @@ import { cancelAllInlineRequests } from "../lib/inlineAi";
 import { useConnectionStore } from "../stores/connectionStore";
 import {
   useInlineAiStore,
+  type BinaryDownloadState,
   type DownloadState,
   type SidecarState,
 } from "../stores/inlineAiStore";
@@ -37,8 +38,20 @@ export function useInlineAiLifecycle(): void {
       ),
     );
 
+    unlisteners.push(
+      listen<BinaryDownloadState>(
+        "inline:binary-download-progress",
+        (event) => {
+          useInlineAiStore
+            .getState()
+            .applyBinaryDownloadProgress(event.payload);
+        },
+      ),
+    );
+
     void store.refreshModels();
     void store.refreshStatus();
+    void store.refreshBinary();
 
     if (store.enabled && store.autoStart) {
       // Best-effort — the sidecar may fail if the model isn't downloaded,

--- a/src/lib/stripThinking.ts
+++ b/src/lib/stripThinking.ts
@@ -20,3 +20,26 @@ export function stripThinkingBlocks(text: string): string {
   }
   return result.trimStart();
 }
+
+/**
+ * Unwrap a response that is entirely one fenced code block
+ * (e.g. ```sql\nSELECT ...\n```). Local instruct models (Qwen-Coder,
+ * DeepSeek-Coder-V2) often do this even when the prompt says not to.
+ *
+ * Only strips when the fence *is* the whole response — mixed prose with
+ * embedded fenced blocks (explain / document flows) is left untouched.
+ * Handles the mid-stream case where the opening fence has arrived but
+ * the closing fence has not.
+ */
+export function stripWrappingCodeFence(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("```")) return text;
+
+  const closed = trimmed.match(/^```[a-zA-Z0-9_+-]*\n?([\s\S]*?)\n?```\s*$/);
+  if (closed) return closed[1];
+
+  const afterOpen = trimmed.replace(/^```[a-zA-Z0-9_+-]*\n?/, "");
+  if (!afterOpen.includes("```")) return afterOpen;
+
+  return text;
+}

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -2,7 +2,24 @@ import { create } from "zustand";
 import { invoke } from "@tauri-apps/api/core";
 import type { AiProviderConfig, AiFlow, AiHistoryEntry, OpenRouterModel } from "../types/ai";
 import { useEditorStore } from "./editorStore";
-import { stripThinkingBlocks } from "../lib/stripThinking";
+import { stripThinkingBlocks, stripWrappingCodeFence } from "../lib/stripThinking";
+
+/** Flows whose response should be bare SQL — strip a wrapping ```sql fence if present. */
+const SQL_RESPONSE_FLOWS: ReadonlySet<AiFlow> = new Set([
+  "generate_sql",
+  "optimize",
+  "format_sql",
+  "comment_sql",
+  "fix_query",
+]);
+
+function normalizeResponse(flow: AiFlow | null, text: string): string {
+  const stripped = stripThinkingBlocks(text);
+  if (flow && SQL_RESPONSE_FLOWS.has(flow)) {
+    return stripWrappingCodeFence(stripped);
+  }
+  return stripped;
+}
 
 interface PaletteOptions {
   flow?: AiFlow;
@@ -264,14 +281,18 @@ export const useAiStore = create<AiState>((set, get) => ({
     const state = get();
     if (state.currentRequestId === requestId) {
       const raw = state.currentResponse + chunk;
-      set({ currentResponse: stripThinkingBlocks(raw) });
+      set({ currentResponse: normalizeResponse(state.currentFlow, raw) });
     }
   },
 
   finishStream: (requestId, fullText) => {
     const state = get();
     if (state.currentRequestId === requestId) {
-      set({ streaming: false, currentResponse: stripThinkingBlocks(fullText), currentRequestId: null });
+      set({
+        streaming: false,
+        currentResponse: normalizeResponse(state.currentFlow, fullText),
+        currentRequestId: null,
+      });
     }
   },
 

--- a/src/stores/inlineAiStore.ts
+++ b/src/stores/inlineAiStore.ts
@@ -66,6 +66,24 @@ export interface CompletionTelemetry {
   preview: string;
 }
 
+/** Mirror of Rust-side `BinaryStatus`. */
+export interface BinaryStatus {
+  /** False on platforms where we don't (yet) offer a runtime download. */
+  supported: boolean;
+  installed: boolean;
+  path: string | null;
+  url: string | null;
+  releaseTag: string;
+}
+
+/** Narrower progress shape than the model downloader — there's only one binary. */
+export interface BinaryDownloadState {
+  downloaded: number;
+  total: number;
+  phase: "started" | "progress" | "extracting" | "completed" | "cancelled" | "error";
+  error?: string;
+}
+
 const TELEMETRY_CAPACITY = 20;
 
 interface InlineAiState extends InlineAiSettings {
@@ -73,6 +91,8 @@ interface InlineAiState extends InlineAiSettings {
   models: ModelListItem[];
   downloads: Record<string, DownloadState>;
   telemetry: CompletionTelemetry[];
+  binary: BinaryStatus;
+  binaryDownload: BinaryDownloadState | null;
 
   // Settings writers
   updateSetting: <K extends keyof InlineAiSettings>(
@@ -84,15 +104,20 @@ interface InlineAiState extends InlineAiSettings {
   // Runtime
   refreshModels: () => Promise<void>;
   refreshStatus: () => Promise<void>;
+  refreshBinary: () => Promise<void>;
   startSidecar: () => Promise<void>;
   stopSidecar: () => Promise<void>;
   downloadModel: (id: string) => Promise<void>;
   cancelDownload: (id: string) => Promise<void>;
   deleteModel: (id: string) => Promise<void>;
+  downloadBinary: () => Promise<void>;
+  cancelBinaryDownload: () => Promise<void>;
+  deleteBinary: () => Promise<void>;
 
   // Event adapters (called from useInlineAiLifecycle)
   applySidecarStatus: (s: SidecarState) => void;
   applyDownloadProgress: (p: { id: string } & DownloadState) => void;
+  applyBinaryDownloadProgress: (p: BinaryDownloadState) => void;
   recordCompletion: (sample: Omit<CompletionTelemetry, "at">) => void;
   clearTelemetry: () => void;
 }
@@ -111,12 +136,22 @@ function saveSettings(settings: InlineAiSettings): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 }
 
+const INITIAL_BINARY: BinaryStatus = {
+  supported: true,
+  installed: false,
+  path: null,
+  url: null,
+  releaseTag: "",
+};
+
 export const useInlineAiStore = create<InlineAiState>((set, get) => ({
   ...loadSettings(),
   sidecar: { state: "stopped" },
   models: [],
   downloads: {},
   telemetry: [],
+  binary: INITIAL_BINARY,
+  binaryDownload: null,
 
   updateSetting: (key, value) => {
     set({ [key]: value } as Partial<InlineAiSettings>);
@@ -141,9 +176,13 @@ export const useInlineAiStore = create<InlineAiState>((set, get) => ({
     // Side effects: when flipping on, auto-start if the selected model
     // is ready on disk. When flipping off, stop the sidecar.
     if (!was) {
+      // Trigger a binary refresh so the settings UI can decide whether
+      // to show the "Download runtime" banner. The sidecar can't start
+      // without the binary — surfacing that state is the UX contract.
+      void get().refreshBinary();
       const { modelId, models } = get();
       const m = models.find((x) => x.id === modelId);
-      if (m?.downloaded && get().sidecar.state !== "ready") {
+      if (m?.downloaded && get().binary.installed && get().sidecar.state !== "ready") {
         try {
           await get().startSidecar();
         } catch {
@@ -170,6 +209,15 @@ export const useInlineAiStore = create<InlineAiState>((set, get) => ({
       set({ sidecar: status });
     } catch (e) {
       console.error("inline_sidecar_status failed:", e);
+    }
+  },
+
+  refreshBinary: async () => {
+    try {
+      const binary = await invoke<BinaryStatus>("inline_binary_status");
+      set({ binary });
+    } catch (e) {
+      console.error("inline_binary_status failed:", e);
     }
   },
 
@@ -221,6 +269,34 @@ export const useInlineAiStore = create<InlineAiState>((set, get) => ({
     }
   },
 
+  downloadBinary: async () => {
+    try {
+      // Mirrors downloadModel: starts a long-running invoke that drives
+      // `inline:binary-download-progress` events until it resolves.
+      await invoke("inline_binary_download");
+      await get().refreshBinary();
+    } catch (e) {
+      console.error("inline_binary_download failed:", e);
+    }
+  },
+
+  cancelBinaryDownload: async () => {
+    try {
+      await invoke("inline_binary_cancel_download");
+    } catch (e) {
+      console.error("inline_binary_cancel_download failed:", e);
+    }
+  },
+
+  deleteBinary: async () => {
+    try {
+      await invoke("inline_binary_delete");
+      await get().refreshBinary();
+    } catch (e) {
+      console.error("inline_binary_delete failed:", e);
+    }
+  },
+
   applySidecarStatus: (status) => {
     set({ sidecar: status });
   },
@@ -251,6 +327,14 @@ export const useInlineAiStore = create<InlineAiState>((set, get) => ({
     // On terminal states, refresh the catalog list so the downloaded flag flips.
     if (p.phase === "completed" || p.phase === "error" || p.phase === "cancelled") {
       void get().refreshModels();
+    }
+  },
+
+  applyBinaryDownloadProgress: (p) => {
+    set({ binaryDownload: p });
+    if (p.phase === "completed" || p.phase === "error" || p.phase === "cancelled") {
+      // Pick up the new on-disk state so the UI can flip the "Download" button off.
+      void get().refreshBinary();
     }
   },
 }));

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -6,7 +6,13 @@ export type AiProviderType =
   | "minimax"
   | "zai"
   | "claudeCodeCli"
-  | "lmStudio";
+  | "lmStudio"
+  | "inlineLocal";
+
+/** Sentinel provider id used for the synthesized "Local inline AI"
+ *  dropdown entry — the backend (`commands.rs`) recognises this id and
+ *  routes the request to the running llama-server sidecar. */
+export const INLINE_LOCAL_PROVIDER_ID = "inline-local";
 
 export interface AiProviderConfig {
   id: string;
@@ -50,6 +56,7 @@ export const AI_PROVIDER_LABELS: Record<AiProviderType, string> = {
   zai: "Z.ai",
   claudeCodeCli: "Claude Code CLI",
   lmStudio: "LM Studio",
+  inlineLocal: "Local (Inline AI)",
 };
 
 export const AI_FLOW_LABELS: Record<AiFlow, string> = {
@@ -81,6 +88,7 @@ const DEFAULT_MODELS: Record<AiProviderType, string> = {
   zai: "GLM-4.7",
   claudeCodeCli: "claude-sonnet-4-20250514",
   lmStudio: "local-model",
+  inlineLocal: "",
 };
 
 const DEFAULT_BASE_URLS: Partial<Record<AiProviderType, string>> = {


### PR DESCRIPTION
## Summary
- **Windows fix**: inline AI now auto-fetches a platform-appropriate `llama-server` from the [upstream llama.cpp release `b8815`](https://github.com/ggml-org/llama.cpp/releases/tag/b8815) on first enable. Windows (Vulkan zip), macOS arm64/x64 (Metal tar.gz), Linux (Vulkan tar.gz). Cached in `<app_data>/inline-ai/bin/`
- New **Sidecar runtime** row in Settings → Inline AI with Download / Delete / cancel / progress. Amber banner when enabled-without-binary
- AI assistant palette: synthetic "Local (Inline AI)" provider entry appears when inline AI is enabled AND the sidecar is Ready; backend routes it through the running llama-server via the existing OpenAI-compatible streaming path
- Response normalisation: strip wrapping ```sql code fences for SQL-flow answers so Qwen / DeepSeek don't leak markdown into the editor
- `SQAIL_LLAMA_SERVER_PATH` still overrides for CUDA / custom builds

## Architecture
- New Rust module `src-tauri/src/ai/inline/binaries.rs` mirrors `models.rs` — resumable HTTP download, `zip` + `tar.gz` extraction (flattens archive's `build/bin/` so DLLs end up next to the exe), emits `inline:binary-download-progress` events
- Sidecar `resolve_server_bin` preference order: `SQAIL_LLAMA_SERVER_PATH` → `resource_dir()` → **new**: `<app_data>/inline-ai/bin/` → dev `.cache/inline-ai/bin/`
- Version bump **0.5.0 → 0.5.1**

## Test plan
- [x] `pnpm check` (tsc) clean
- [x] `cargo check` clean
- [x] `pnpm lint` clean (pre-existing DataGrid warning only)
- [ ] Windows: fresh install, enable inline AI, verify auto-download of Vulkan build and sidecar starts
- [ ] macOS arm64: same flow with Metal tar.gz
- [ ] Linux: Vulkan tar.gz flow (CUDA users still use SQAIL_LLAMA_SERVER_PATH or fetch-llama-cpp.sh)
- [ ] AI palette: verify "Local (Inline AI)" entry appears when sidecar Ready, generates SQL via llama-server
- [ ] Format/optimize with Qwen-3B: confirm no ```sql fences leak through

🤖 Generated with [Claude Code](https://claude.com/claude-code)