### PR TITLE
feat: allow setting local inline AI as default provider (v0.5.2)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,11 @@
 
 ## Unreleased
 
+## v0.5.2
+
+### Inline AI
+- New **Use as default AI provider** toggle in Settings → Inline AI — when on (and inline AI is enabled + sidecar ready), the AI command palette routes flows with no explicit provider selection through the local sidecar instead of the persisted default
+
 ## v0.5.1
 
 ### Inline AI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqail",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.5.2",
+    "sections": [
+      {
+        "title": "Inline AI",
+        "items": [
+          "New 'Use as default AI provider' toggle in Settings \u2192 Inline AI \u2014 when on (and inline AI is enabled + sidecar ready), the AI command palette routes flows with no explicit provider selection through the local sidecar instead of the persisted default"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.1",
     "sections": [
       {

--- a/sqail.portal/releases.json
+++ b/sqail.portal/releases.json
@@ -1,5 +1,16 @@
 [
   {
+    "version": "0.5.2",
+    "sections": [
+      {
+        "title": "Inline AI",
+        "items": [
+          "New 'Use as default AI provider' toggle in Settings \u2192 Inline AI \u2014 when on (and inline AI is enabled + sidecar ready), the AI command palette routes flows with no explicit provider selection through the local sidecar instead of the persisted default"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.1",
     "sections": [
       {

--- a/sqail.portal/src/lib/constants.ts
+++ b/sqail.portal/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.5.1";
+export const VERSION = "0.5.2";
 export const BUILD_NUMBER = "20260411-1";
 export const GITHUB_URL = "https://github.com/bartbeecoders/sqail";
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "sqail"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "bb8",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqail"
-version = "0.5.1"
+version = "0.5.2"
 description = "A lightweight SQL database editor with AI integration"
 authors = ["sqail"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "sqail",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "dev.sqail",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/AiCommandPalette.tsx
+++ b/src/components/AiCommandPalette.tsx
@@ -14,10 +14,10 @@ import { useEditorStore } from "../stores/editorStore";
 import { useConnectionStore } from "../stores/connectionStore";
 import { useInlineAiStore } from "../stores/inlineAiStore";
 import { buildSchemaContext } from "../lib/schemaContext";
+import { buildVirtualInlineProvider } from "../lib/inlineProvider";
 import {
   AI_FLOW_LABELS,
   AI_PROVIDER_LABELS,
-  INLINE_LOCAL_PROVIDER_ID,
 } from "../types/ai";
 import type { AiFlow, AiHistoryEntry, AiProviderConfig } from "../types/ai";
 import { invoke } from "@tauri-apps/api/core";
@@ -95,20 +95,11 @@ export default function AiCommandPalette() {
   const inlineEnabled = useInlineAiStore((s) => s.enabled);
   const inlineSidecar = useInlineAiStore((s) => s.sidecar);
   const inlineModels = useInlineAiStore((s) => s.models);
-  const virtualInlineProvider = useMemo<AiProviderConfig | null>(() => {
-    if (!inlineEnabled) return null;
-    if (inlineSidecar.state !== "ready") return null;
-    const model = inlineModels.find((m) => m.id === inlineSidecar.modelId);
-    const label = model?.displayName ?? inlineSidecar.modelId;
-    return {
-      id: INLINE_LOCAL_PROVIDER_ID,
-      name: `Local (${label})`,
-      provider: "inlineLocal",
-      apiKey: "",
-      model: inlineSidecar.modelId,
-      isDefault: false,
-    };
-  }, [inlineEnabled, inlineSidecar, inlineModels]);
+  const inlineUseAsDefault = useInlineAiStore((s) => s.useAsDefaultProvider);
+  const virtualInlineProvider = useMemo<AiProviderConfig | null>(
+    () => buildVirtualInlineProvider(inlineEnabled, inlineSidecar, inlineModels),
+    [inlineEnabled, inlineSidecar, inlineModels],
+  );
 
   const displayProviders = useMemo<AiProviderConfig[]>(() => {
     return virtualInlineProvider
@@ -117,7 +108,10 @@ export default function AiCommandPalette() {
   }, [providers, virtualInlineProvider]);
 
   const hasProvider = displayProviders.length > 0;
-  const defaultProvider = getDefaultProvider();
+  const defaultProvider =
+    inlineUseAsDefault && virtualInlineProvider
+      ? virtualInlineProvider
+      : getDefaultProvider();
 
   // Load providers on mount
   useEffect(() => {

--- a/src/components/InlineAiSettingsTab.tsx
+++ b/src/components/InlineAiSettingsTab.tsx
@@ -156,6 +156,12 @@ export default function InlineAiSettingsTab() {
               onChange={(v) => s.updateSetting("cpuOnly", v)}
             />
           </Row>
+          <Row label="Use as default AI provider">
+            <Toggle
+              checked={s.useAsDefaultProvider}
+              onChange={(v) => s.updateSetting("useAsDefaultProvider", v)}
+            />
+          </Row>
           <Row label="Show latency telemetry">
             <Toggle
               checked={s.devMode}

--- a/src/lib/inlineProvider.ts
+++ b/src/lib/inlineProvider.ts
@@ -1,0 +1,51 @@
+import type { AiProviderConfig } from "../types/ai";
+import { INLINE_LOCAL_PROVIDER_ID } from "../types/ai";
+import {
+  useInlineAiStore,
+  type ModelListItem,
+  type SidecarState,
+} from "../stores/inlineAiStore";
+
+/**
+ * Build the virtual "Local (Inline AI)" provider entry the palette + AI
+ * assistant show in their dropdowns. Returns `null` when the sidecar
+ * isn't in a state that can actually serve requests — caller shouldn't
+ * render or dispatch against it in that case.
+ *
+ * Takes state as explicit arguments so React-side callers can pass them
+ * directly to `useMemo` deps without tripping `exhaustive-deps`.
+ */
+export function buildVirtualInlineProvider(
+  enabled: boolean,
+  sidecar: SidecarState,
+  models: ModelListItem[],
+): AiProviderConfig | null {
+  if (!enabled) return null;
+  if (sidecar.state !== "ready") return null;
+  const { modelId } = sidecar;
+  const model = models.find((m) => m.id === modelId);
+  const label = model?.displayName ?? modelId;
+  return {
+    id: INLINE_LOCAL_PROVIDER_ID,
+    name: `Local (${label})`,
+    provider: "inlineLocal",
+    apiKey: "",
+    model: modelId,
+    isDefault: false,
+  };
+}
+
+/** Snapshot-reading variant for non-React callers (dispatchers). */
+export function selectVirtualInlineProvider(): AiProviderConfig | null {
+  const s = useInlineAiStore.getState();
+  return buildVirtualInlineProvider(s.enabled, s.sidecar, s.models);
+}
+
+/** True when the user has asked for the inline sidecar to act as the
+ *  default AI provider AND it is actually available right now. */
+export function inlineIsEffectiveDefault(): boolean {
+  const s = useInlineAiStore.getState();
+  return (
+    s.useAsDefaultProvider && s.enabled && s.sidecar.state === "ready"
+  );
+}

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -3,6 +3,21 @@ import { invoke } from "@tauri-apps/api/core";
 import type { AiProviderConfig, AiFlow, AiHistoryEntry, OpenRouterModel } from "../types/ai";
 import { useEditorStore } from "./editorStore";
 import { stripThinkingBlocks, stripWrappingCodeFence } from "../lib/stripThinking";
+import {
+  inlineIsEffectiveDefault,
+  selectVirtualInlineProvider,
+} from "../lib/inlineProvider";
+import { INLINE_LOCAL_PROVIDER_ID } from "../types/ai";
+
+/** Resolve the provider id to send to the backend for a flow.
+ *  - If the user explicitly picked a provider in the palette, honour that.
+ *  - Else if inline-as-default is active, route to the sidecar.
+ *  - Else null (backend picks the persisted default). */
+function resolveDispatchProviderId(selected: string | null): string | null {
+  if (selected) return selected;
+  if (inlineIsEffectiveDefault()) return INLINE_LOCAL_PROVIDER_ID;
+  return null;
+}
 
 /** Flows whose response should be bare SQL — strip a wrapping ```sql fence if present. */
 const SQL_RESPONSE_FLOWS: ReadonlySet<AiFlow> = new Set([
@@ -158,6 +173,10 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   getDefaultProvider: () => {
+    if (inlineIsEffectiveDefault()) {
+      const v = selectVirtualInlineProvider();
+      if (v) return v;
+    }
     const { providers } = get();
     return providers.find((p) => p.isDefault) ?? providers[0];
   },
@@ -195,7 +214,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   generateSql: async (prompt, schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "generate_sql" });
     try {
       const requestId = await invoke<string>("ai_generate_sql", { prompt, schemaContext, driver, providerId });
@@ -206,7 +225,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   explainQuery: async (sql, schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "explain" });
     try {
       const requestId = await invoke<string>("ai_explain_query", { sql, schemaContext, driver, providerId });
@@ -217,7 +236,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   optimizeQuery: async (sql, schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "optimize" });
     try {
       const requestId = await invoke<string>("ai_optimize_query", { sql, schemaContext, driver, providerId });
@@ -228,7 +247,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   generateDocs: async (schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "document" });
     try {
       const requestId = await invoke<string>("ai_generate_docs", { schemaContext, driver, providerId });
@@ -239,7 +258,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   formatSql: async (sql, schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "format_sql" });
     try {
       const requestId = await invoke<string>("ai_format_sql", { sql, schemaContext, driver, providerId });
@@ -250,7 +269,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   commentSql: async (sql, schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "comment_sql" });
     try {
       const requestId = await invoke<string>("ai_comment_sql", { sql, schemaContext, driver, providerId });
@@ -261,7 +280,7 @@ export const useAiStore = create<AiState>((set, get) => ({
   },
 
   fixQuery: async (sql, errorMessage, schemaContext, driver) => {
-    const providerId = get().selectedProviderId;
+    const providerId = resolveDispatchProviderId(get().selectedProviderId);
     set({ streaming: true, currentResponse: "", error: null, currentFlow: "fix_query" });
     try {
       const requestId = await invoke<string>("ai_fix_query", {

--- a/src/stores/inlineAiStore.ts
+++ b/src/stores/inlineAiStore.ts
@@ -15,6 +15,12 @@ export interface InlineAiSettings {
   ctxSize: number;
   /** When true, show a per-completion latency table in the settings tab. */
   devMode: boolean;
+  /**
+   * When true (and inline AI is enabled and the sidecar is ready), the AI
+   * assistant palette routes flows with no explicit provider selection
+   * through the local sidecar instead of the persisted default.
+   */
+  useAsDefaultProvider: boolean;
 }
 
 const DEFAULTS: InlineAiSettings = {
@@ -27,6 +33,7 @@ const DEFAULTS: InlineAiSettings = {
   cpuOnly: false,
   ctxSize: 4096,
   devMode: false,
+  useAsDefaultProvider: false,
 };
 
 /** Mirror of Rust-side `SidecarStatus`. */
@@ -166,6 +173,7 @@ export const useInlineAiStore = create<InlineAiState>((set, get) => ({
       cpuOnly: snapshot.cpuOnly,
       ctxSize: snapshot.ctxSize,
       devMode: snapshot.devMode,
+      useAsDefaultProvider: snapshot.useAsDefaultProvider,
     };
     saveSettings(toSave);
   },


### PR DESCRIPTION
## Summary
- New **Use as default AI provider** toggle in Settings → Inline AI
- When on (and inline AI is enabled + sidecar ready), AI command palette flows with no explicit provider selection route through the local `llama-server` sidecar instead of the persisted cloud default
- `aiStore.getDefaultProvider()` and every flow dispatcher are inline-aware; "default" badge in the palette reflects the active default

## Implementation
- New `useAsDefaultProvider: boolean` in persisted inline AI settings (localStorage)
- `src/lib/inlineProvider.ts` centralises virtual-provider construction
  - `buildVirtualInlineProvider(enabled, sidecar, models)` — React-safe, visible deps for `useMemo`
  - `selectVirtualInlineProvider()` — snapshot variant for zustand action callers
  - `inlineIsEffectiveDefault()` — single source of truth for the gating rule
- Dispatch layer: `resolveDispatchProviderId(selected)` sends the sentinel `"inline-local"` id when user didn't pick + inline is the active default
- Version bump **0.5.1 → 0.5.2**

## Test plan
- [x] `pnpm check` clean
- [x] `pnpm lint` clean (pre-existing DataGrid warning only)
- [x] `cargo check` clean (no Rust changes but Cargo.lock version synced)
- [ ] Enable inline AI, start sidecar, toggle 'Use as default AI provider' on. Open command palette — default badge should move to "Local (model)"
- [ ] Fire a flow without explicitly selecting a provider — response should come from local sidecar
- [ ] Toggle off — default reverts to persisted provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)