### PR TITLE
fix: sidecar starting label + wider ctx-size range (v0.5.3)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,12 @@
 
 ## Unreleased
 
+## v0.5.3
+
+### Inline AI
+- Fix "Starting undefined" label during sidecar startup — the `Starting` variant of the Rust-side sidecar status was emitted with snake_case `model_id` while the frontend expected camelCase `modelId`. Applied `rename_all_fields = "camelCase"` to the enum so all variants convert consistently
+- Context window dropdown widened to 16384 / 32768 for users routing AI-assistant flows (explain / optimize / docs) through the local sidecar — the default 4096 overflows on schema-heavy prompts. Helper text notes that a sidecar restart is required to apply
+
 ## v0.5.2
 
 ### Inline AI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqail",
   "private": true,
-  "version": "0.5.2",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.5.3",
+    "sections": [
+      {
+        "title": "Inline AI",
+        "items": [
+          "Fix 'Starting undefined' label during sidecar startup \u2014 the Starting variant of the sidecar status was emitted with snake_case model_id while the frontend expected camelCase modelId",
+          "Context window dropdown widened to 16384 / 32768 for users routing AI-assistant flows (explain / optimize / docs) through the local sidecar; a sidecar restart is required to apply"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.2",
     "sections": [
       {

--- a/sqail.portal/releases.json
+++ b/sqail.portal/releases.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "0.5.3",
+    "sections": [
+      {
+        "title": "Inline AI",
+        "items": [
+          "Fix 'Starting undefined' label during sidecar startup \u2014 the Starting variant of the sidecar status was emitted with snake_case model_id while the frontend expected camelCase modelId",
+          "Context window dropdown widened to 16384 / 32768 for users routing AI-assistant flows (explain / optimize / docs) through the local sidecar; a sidecar restart is required to apply"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.2",
     "sections": [
       {

--- a/sqail.portal/src/lib/constants.ts
+++ b/sqail.portal/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.5.2";
+export const VERSION = "0.5.3";
 export const BUILD_NUMBER = "20260411-1";
 export const GITHUB_URL = "https://github.com/bartbeecoders/sqail";
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "sqail"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "bb8",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqail"
-version = "0.5.2"
+version = "0.5.3"
 description = "A lightweight SQL database editor with AI integration"
 authors = ["sqail"]
 license = "MIT"

--- a/src-tauri/src/ai/inline/sidecar.rs
+++ b/src-tauri/src/ai/inline/sidecar.rs
@@ -32,11 +32,14 @@ const MAX_RESTARTS: u32 = 3;
 
 /// State machine visible to the frontend.
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "state", rename_all = "camelCase")]
+#[serde(
+    tag = "state",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum SidecarStatus {
     Stopped,
     Starting { model_id: String },
-    #[serde(rename_all = "camelCase")]
     Ready { model_id: String, port: u16 },
     Error { message: String },
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "sqail",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "identifier": "dev.sqail",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/InlineAiSettingsTab.tsx
+++ b/src/components/InlineAiSettingsTab.tsx
@@ -132,17 +132,24 @@ export default function InlineAiSettingsTab() {
             />
           </Row>
           <Row label="Context window (tokens)">
-            <select
-              value={s.ctxSize}
-              onChange={(e) =>
-                s.updateSetting("ctxSize", Number(e.target.value))
-              }
-              className="input w-28"
-            >
-              <option value={2048}>2048</option>
-              <option value={4096}>4096</option>
-              <option value={8192}>8192</option>
-            </select>
+            <div className="flex flex-col items-end gap-0.5">
+              <select
+                value={s.ctxSize}
+                onChange={(e) =>
+                  s.updateSetting("ctxSize", Number(e.target.value))
+                }
+                className="input w-28"
+              >
+                <option value={2048}>2048</option>
+                <option value={4096}>4096</option>
+                <option value={8192}>8192</option>
+                <option value={16384}>16384</option>
+                <option value={32768}>32768</option>
+              </select>
+              <span className="text-[10px] text-muted-foreground">
+                Restart sidecar to apply · higher = more VRAM
+              </span>
+            </div>
           </Row>
           <Row label="Auto-start sidecar on launch">
             <Toggle


### PR DESCRIPTION
## Summary
Two small fixes surfaced while bringing up the local inline AI on a real schema.

- **Fix \"Starting undefined…\" label.** `SidecarStatus::Starting { model_id }` serialized with snake_case \`model_id\` while the frontend expected \`modelId\`. Applied \`rename_all_fields = \"camelCase\"\` on the enum so every variant converts consistently.
- **Context window dropdown widened.** Was 2048 / 4096 / 8192 — 4K overflows on schema-heavy AI-assistant prompts when routed through the local sidecar (seeing 17K prompt tokens in practice). Added 16384 / 32768 options with a \"restart sidecar to apply\" hint.

Version bump **0.5.2 → 0.5.3**.

## Test plan
- [x] \`pnpm check\` clean
- [x] \`cargo check\` clean
- [ ] Start sidecar — label should read \"Starting <model-id>…\" instead of \"Starting undefined…\"
- [ ] Pick 32768 ctx, Stop+Start sidecar, run a schema-heavy AI-assistant prompt routed through local — should no longer 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)