### PR TITLE
fix: populate updater pubkey and guard empty signatures (#34)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,24 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Verify updater signatures are present
+        run: |
+          PREFIX="${{ needs.prepare.outputs.file_prefix }}"
+          missing=0
+          for f in \
+            "artifacts/${PREFIX}_amd64.AppImage.sig" \
+            "artifacts/${PREFIX}_x64-setup.nsis.zip.sig" \
+            "artifacts/${PREFIX}_universal.app.tar.gz.sig"; do
+            if [ ! -s "$f" ]; then
+              echo "::error::Missing updater signature: $f"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::Updater signing is not configured. Set TAURI_SIGNING_PRIVATE_KEY and TAURI_SIGNING_PRIVATE_KEY_PASSWORD secrets, or the release will ship a manifest with empty signatures that the client cannot parse (issue #34)."
+            exit 1
+          fi
+
       - name: Generate latest.json for Tauri updater
         run: |
           VERSION="${{ needs.prepare.outputs.app_version }}"
@@ -432,13 +450,11 @@ jobs:
           TAG="v${VERSION}"
           BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
 
-          # Read signature files (may not exist if signing key wasn't set)
-          LINUX_SIG=""
-          WINDOWS_SIG=""
-          MACOS_SIG=""
-          [ -f "artifacts/${PREFIX}_amd64.AppImage.sig" ] && LINUX_SIG=$(cat "artifacts/${PREFIX}_amd64.AppImage.sig")
-          [ -f "artifacts/${PREFIX}_x64-setup.nsis.zip.sig" ] && WINDOWS_SIG=$(cat "artifacts/${PREFIX}_x64-setup.nsis.zip.sig")
-          [ -f "artifacts/${PREFIX}_universal.app.tar.gz.sig" ] && MACOS_SIG=$(cat "artifacts/${PREFIX}_universal.app.tar.gz.sig")
+          # Signatures are verified present by the preceding step —
+          # reading them here is now infallible.
+          LINUX_SIG=$(cat "artifacts/${PREFIX}_amd64.AppImage.sig")
+          WINDOWS_SIG=$(cat "artifacts/${PREFIX}_x64-setup.nsis.zip.sig")
+          MACOS_SIG=$(cat "artifacts/${PREFIX}_universal.app.tar.gz.sig")
 
           # Extract release notes from releases.json
           NOTES=$(python3 -c "

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,13 @@
 
 ## Unreleased
 
+## v0.5.4
+
+### Auto-update (fix #34)
+- Populate the updater public key in `tauri.conf.json` so installed apps can verify minisign signatures. The key was empty since v0.4.2, causing `"invalid encoding in minisign data"` on Windows updates once CI started shipping a signature field
+- CI now hard-fails the release when any per-platform `.sig` file is missing, preventing the release pipeline from silently publishing a manifest with empty signatures
+- **One-time action required** after upgrading: manually install v0.5.4 once — the auto-updater in older installs can't validate the new signature chain
+
 ## v0.5.3
 
 ### Inline AI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sqail",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/releases.json
+++ b/releases.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "0.5.4",
+    "sections": [
+      {
+        "title": "Auto-update (fix #34)",
+        "items": [
+          "Populate the updater public key in tauri.conf.json so installed apps can verify minisign signatures. The key was empty since v0.4.2, causing 'invalid encoding in minisign data' on Windows updates",
+          "CI hard-fails the release when any per-platform .sig file is missing, preventing the release pipeline from silently publishing a manifest with empty signatures",
+          "One-time action required: manually install v0.5.4 once \u2014 the auto-updater in older installs can't validate the new signature chain"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.3",
     "sections": [
       {

--- a/sqail.portal/releases.json
+++ b/sqail.portal/releases.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "0.5.4",
+    "sections": [
+      {
+        "title": "Auto-update (fix #34)",
+        "items": [
+          "Populate the updater public key in tauri.conf.json so installed apps can verify minisign signatures. The key was empty since v0.4.2, causing 'invalid encoding in minisign data' on Windows updates",
+          "CI hard-fails the release when any per-platform .sig file is missing, preventing the release pipeline from silently publishing a manifest with empty signatures",
+          "One-time action required: manually install v0.5.4 once \u2014 the auto-updater in older installs can't validate the new signature chain"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.5.3",
     "sections": [
       {

--- a/sqail.portal/src/lib/constants.ts
+++ b/sqail.portal/src/lib/constants.ts
@@ -1,4 +1,4 @@
-export const VERSION = "0.5.3";
+export const VERSION = "0.5.4";
 export const BUILD_NUMBER = "20260411-1";
 export const GITHUB_URL = "https://github.com/bartbeecoders/sqail";
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "sqail"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "bb8",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqail"
-version = "0.5.3"
+version = "0.5.4"
 description = "A lightweight SQL database editor with AI integration"
 authors = ["sqail"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -33,7 +33,7 @@
       "endpoints": [
         "https://github.com/bartbeecoders/sqail/releases/latest/download/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQ5MjFDQTQ3OTJBRkZGNjMKUldSai82K1NSOG9oMlhuOU1DYzZzNzhkdVMrdW91S1lFbmo5NEZ2QXAvU21CVmVTdldyb1hrSG0K"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDM1NjU2NzlGNERBQUQxMDAKUldRQTBhcE5uMmRsTmZEMjlkWkZwSitzQlc5d0c4VGJhNjh1eWZHZXdCdzNmN2s5K3djUUtBM3EK"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "sqail",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "identifier": "dev.sqail",
   "build": {
     "frontendDist": "../dist",
@@ -33,7 +33,7 @@
       "endpoints": [
         "https://github.com/bartbeecoders/sqail/releases/latest/download/latest.json"
       ],
-      "pubkey": ""
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEQ5MjFDQTQ3OTJBRkZGNjMKUldSai82K1NSOG9oMlhuOU1DYzZzNzhkdVMrdW91S1lFbmo5NEZ2QXAvU21CVmVTdldyb1hrSG0K"
     }
   },
   "bundle": {


### PR DESCRIPTION
Fixes #34 — Windows auto-update fails with *"update failed: invalid encoding in minisign data"*.

## Root cause
1. `tauri.conf.json > plugins.updater.pubkey` has been `""` since v0.4.2. The signing keypair was never generated, despite the helper script `scripts/generate-updater-keys.sh` being shipped at the time.
2. Consequently the GitHub Actions secrets `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` were never populated. Every CI build ran without signing, producing no `.sig` artifacts.
3. The release job's `[ -f "*.sig" ] && SIG=$(cat ...)` checks silently fell through, so `latest.json` shipped `"signature": ""` for every platform.
4. The client-side `tauri-plugin-updater` + `minisign-verify` combo can't parse an empty signature string → `"invalid encoding in minisign data"`.

## What this PR does
- Populates `updater.pubkey` in `tauri.conf.json` with a freshly-generated minisign public key. The private half is left on my local disk at `~/.tauri/sqail.key` for the maintainer to paste into secrets (see below).
- Adds a **Verify updater signatures are present** step in `release.yml` that fails the release job when any per-platform `.sig` file is missing. Prevents future silent regressions and makes misconfiguration loud.
- Bumps version 0.5.3 → 0.5.4.

## ⚠ REQUIRED maintainer actions before tagging v0.5.4

1. **Add GitHub repo secrets** (Settings → Secrets and variables → Actions):
   - `TAURI_SIGNING_PRIVATE_KEY` = contents of `~/.tauri/sqail.key` (full base64 blob)
   - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` = empty string (the key was generated with no password)
2. Merge this PR.
3. Tag `v0.5.4` and push — CI will now:
   - Sign the NSIS / AppImage / macOS tarball during bundle step
   - Refuse to generate `latest.json` if any `.sig` is missing
   - Publish a manifest with real, non-empty signatures
4. **Manually** install v0.5.4 once on existing machines. The in-the-wild auto-updater installed alongside v0.5.3 and earlier has an empty pubkey baked in and will keep hitting the parse error even with valid signatures upstream. Fresh installs of v0.5.4 onward will auto-update normally.

## Test plan
- [x] `pnpm check` clean
- [x] `cargo check` clean
- [ ] After secrets set + release cut: `curl -sL https://github.com/bartbeecoders/sqail/releases/latest/download/latest.json | jq '.platforms["windows-x86_64"].signature'` returns a non-empty base64 blob
- [ ] Fresh v0.5.4 install on Windows → test auto-update to a subsequent release

🤖 Generated with [Claude Code](https://claude.com/claude-code)