### PR TITLE
Schema diagram tab + local LLM/LoRA portal highlights

### DIFF
--- a/Vibecoding/marketing.md
+++ b/Vibecoding/marketing.md
@@ -37,3 +37,10 @@ Make it look professional and modern. Use the image-gen plugin to generate the s
 Can you change the app icon to the 'snail' like image.
 
 Add a marketing folder with a marketing plan and a marketing strategy.
+
+
+Update the portal to highlight the new features and improvements.
+
+- new diagraming feature
+- Local LLM support
+- Local LLM training and fine-tuning

--- a/sqail.portal/src/components/AiSection.tsx
+++ b/sqail.portal/src/components/AiSection.tsx
@@ -1,4 +1,4 @@
-import { Bot, Sparkles, FileText, Wand2 } from "lucide-react";
+import { Bot, Cpu, FileText, GraduationCap, HardDrive, Sparkles, Wand2 } from "lucide-react";
 import { AI_PROVIDERS } from "../lib/constants";
 
 const AI_FEATURES = [
@@ -24,6 +24,27 @@ const AI_FEATURES = [
   },
 ];
 
+const LOCAL_AI_FEATURES = [
+  {
+    icon: <HardDrive size={20} />,
+    title: "100% offline inline AI",
+    description:
+      "A bundled llama.cpp sidecar runs GGUF models locally for ghost-text and assistant flows. Auto-download on first enable — Vulkan on Windows/Linux, Metal on macOS.",
+  },
+  {
+    icon: <Cpu size={20} />,
+    title: "Curated model catalog",
+    description:
+      "Qwen2.5-Coder 0.5B / 7B / 14B, Qwen3.5 9B / 27B, Qwen3-Coder 30B-A3B MoE, and Qwen3.6 35B-A3B — VRAM-gated so you only see models your GPU can actually load.",
+  },
+  {
+    icon: <GraduationCap size={20} />,
+    title: "Database-tuned LoRA fine-tuning",
+    description:
+      "Pick a connection + a base model, and sqail builds a JSONL corpus from your schema, metadata, and sample rows, then runs a LoRA fine-tune on your local GPU. Activate the adapter with one click — no restart.",
+  },
+];
+
 export default function AiSection() {
   return (
     <section id="ai" className="bg-bg-section py-24">
@@ -36,9 +57,9 @@ export default function AiSection() {
               <span className="text-brand-yellow">SQL intelligence</span>
             </h2>
             <p className="mb-8 text-text-muted">
-              SQaiL integrates with your favorite AI provider to supercharge your
-              database workflow. Write queries faster, understand complex SQL
-              instantly, and document your schema automatically.
+              Cloud or local — sqail works with your favorite AI provider, or
+              runs entirely on your machine. Write queries faster, understand
+              complex SQL instantly, and document your schema automatically.
             </p>
 
             <div className="space-y-5">
@@ -87,6 +108,42 @@ export default function AiSection() {
                 AI providers supported — from cloud APIs to local models
               </p>
             </div>
+          </div>
+        </div>
+
+        {/* Local AI + training */}
+        <div className="mt-20 border-t border-border pt-16">
+          <div className="mb-12 max-w-3xl">
+            <span className="mb-3 inline-flex items-center gap-2 rounded-full border border-brand-yellow/30 bg-brand-yellow/5 px-3 py-1 text-xs font-semibold text-brand-yellow">
+              New in 0.6
+            </span>
+            <h3 className="mb-3 text-2xl font-bold text-text-primary sm:text-3xl">
+              Local LLM &amp; on-device fine-tuning
+            </h3>
+            <p className="text-text-muted">
+              No API key, no round-trip, no vendor lock-in. Run open-weight
+              models on your own GPU — and teach one your specific schema with
+              a LoRA fine-tune kicked off from the Settings UI.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-3">
+            {LOCAL_AI_FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-xl border border-border bg-bg-primary p-6 transition-colors hover:border-brand-yellow/40"
+              >
+                <div className="mb-4 inline-flex rounded-lg bg-brand-yellow/10 p-2.5 text-brand-yellow">
+                  {f.icon}
+                </div>
+                <h4 className="mb-2 text-base font-semibold text-text-primary">
+                  {f.title}
+                </h4>
+                <p className="text-sm leading-relaxed text-text-muted">
+                  {f.description}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/sqail.portal/src/components/Features.tsx
+++ b/sqail.portal/src/components/Features.tsx
@@ -4,6 +4,7 @@ import {
   GitBranch,
   ShieldCheck,
   Database,
+  Network,
 } from "lucide-react";
 import { FEATURES } from "../lib/constants";
 
@@ -13,13 +14,15 @@ const ICON_MAP: Record<string, React.ReactNode> = {
   GitBranch: <GitBranch size={24} />,
   ShieldCheck: <ShieldCheck size={24} />,
   Database: <Database size={24} />,
+  Network: <Network size={24} />,
 };
 
 // Smart and Private use yellow per brand-guide §3 ("yellow owns intelligence / AI").
-// Fast, Free, Universal use cyan.
+// Fast, Free, Universal, Visual use cyan.
 const ACCENT_MAP: Record<string, "cyan" | "yellow"> = {
   Fast: "cyan",
   Smart: "yellow",
+  Visual: "cyan",
   Free: "cyan",
   Private: "yellow",
   Universal: "cyan",
@@ -31,7 +34,7 @@ export default function Features() {
       <div className="mx-auto max-w-6xl px-6">
         <div className="mb-16 text-center">
           <h2 className="mb-4 text-3xl font-bold text-text-primary sm:text-4xl">
-            Five things sqail does well
+            Six things sqail does well
           </h2>
           <p className="mx-auto max-w-2xl text-text-muted">
             Everything else is intentionally out of scope. We'd rather ship one

--- a/sqail.portal/src/components/Hero.tsx
+++ b/sqail.portal/src/components/Hero.tsx
@@ -34,11 +34,20 @@ export default function Hero() {
             </span>
           </h1>
 
-          <p className="mb-8 max-w-lg text-lg leading-relaxed text-text-muted">
+          <p className="mb-6 max-w-lg text-lg leading-relaxed text-text-muted">
             A lightweight, cross-platform desktop SQL editor with built-in AI.
             Connect to PostgreSQL, MySQL, SQLite, or SQL Server — and let AI
             help you write, explain, and optimize your queries.
           </p>
+
+          <div className="mb-8 flex flex-wrap gap-2">
+            <span className="rounded-full border border-brand-cyan/30 bg-brand-cyan/5 px-3 py-1 text-xs font-medium text-brand-cyan">
+              New: drag-and-drop schema diagrams
+            </span>
+            <span className="rounded-full border border-brand-yellow/30 bg-brand-yellow/5 px-3 py-1 text-xs font-medium text-brand-yellow">
+              Local LLM + LoRA fine-tuning
+            </span>
+          </div>
 
           <div className="flex flex-wrap gap-4">
             <a

--- a/sqail.portal/src/lib/constants.ts
+++ b/sqail.portal/src/lib/constants.ts
@@ -1,5 +1,5 @@
-export const VERSION = "0.5.4";
-export const BUILD_NUMBER = "20260411-1";
+export const VERSION = "0.6.0";
+export const BUILD_NUMBER = "20260418-1";
 export const GITHUB_URL = "https://github.com/bartbeecoders/sqail";
 
 export type Platform = "windows" | "macos" | "linux";
@@ -97,8 +97,14 @@ export const FEATURES = [
   {
     icon: "Sparkles",
     title: "Smart",
-    headline: "AI that actually knows your schema.",
-    description: "Schema-aware autocomplete and NL-to-SQL with your tables injected as context. Bring your own key.",
+    headline: "Cloud AI or a local model — your call.",
+    description: "Schema-aware NL-to-SQL and inline completions, backed by your favorite API, a local llama.cpp sidecar, or a LoRA fine-tune trained on your own database.",
+  },
+  {
+    icon: "Network",
+    title: "Visual",
+    headline: "Drag-and-drop schema diagrams.",
+    description: "Drop tables from the object browser onto a canvas. Zoom, pan, recolor, annotate, and export as PNG, SVG, PDF, or .drawio — all in-app, no Graphviz install.",
   },
   {
     icon: "GitBranch",
@@ -110,7 +116,7 @@ export const FEATURES = [
     icon: "ShieldCheck",
     title: "Private",
     headline: "Your queries stay on your machine.",
-    description: "No telemetry. Credentials live in a local encrypted store. AI providers are only called when you configure them.",
+    description: "No telemetry. Credentials live in a local encrypted store. AI providers are only called when you configure them — and local mode stays fully offline.",
   },
   {
     icon: "Database",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -18,7 +18,7 @@ use crate::db::connections::{ConnectionConfig, Driver, MssqlAuthMethod};
 use crate::metadata::{ColumnMetadata, GeneratedMetadata, ObjectMetadata};
 use crate::pool::DbPool;
 use crate::query::{self, QueryResponse};
-use crate::schema::{self, ColumnInfo, IndexInfo, RoutineInfo, SchemaInfo, TableInfo};
+use crate::schema::{self, ColumnInfo, ForeignKeyInfo, IndexInfo, RoutineInfo, SchemaInfo, TableInfo};
 use crate::state::AppState;
 
 #[tauri::command]
@@ -487,6 +487,16 @@ pub async fn list_routines(
 ) -> Result<Vec<RoutineInfo>, String> {
     let (pool, driver) = get_pool_and_driver(&state, &connection_id).await?;
     schema::list_routines(pool, &driver, &schema_name).await
+}
+
+#[tauri::command]
+pub async fn list_foreign_keys(
+    state: State<'_, AppState>,
+    connection_id: String,
+    schema_name: String,
+) -> Result<Vec<ForeignKeyInfo>, String> {
+    let (pool, driver) = get_pool_and_driver(&state, &connection_id).await?;
+    schema::list_foreign_keys(pool, &driver, &schema_name).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,7 @@ pub fn run() {
             commands::list_columns,
             commands::list_indexes,
             commands::list_routines,
+            commands::list_foreign_keys,
             commands::get_view_definition,
             commands::get_routine_definition,
             commands::start_entra_login,

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -46,6 +46,19 @@ pub struct RoutineInfo {
     pub routine_type: String, // "function" or "procedure"
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForeignKeyInfo {
+    pub constraint_name: String,
+    pub source_schema: String,
+    pub source_table: String,
+    pub source_column: String,
+    pub target_schema: String,
+    pub target_table: String,
+    pub target_column: String,
+    pub ordinal: i32,
+}
+
 // ── PostgreSQL ──────────────────────────────────────────────
 
 async fn pg_schemas(pool: &sqlx::PgPool) -> Result<Vec<SchemaInfo>, String> {
@@ -964,5 +977,180 @@ pub async fn get_routine_definition(
         Driver::Sqlite => Err("SQLite does not support stored routines".to_string()),
         Driver::Mssql => mssql_routine_definition(get_mssql_pool(&pool)?, schema, name).await,
         Driver::Dbservice => Err("Routine definitions not supported via DbService".to_string()),
+    }
+}
+
+// ── Foreign keys ────────────────────────────────────────────
+
+async fn pg_foreign_keys(pool: &sqlx::PgPool, schema: &str) -> Result<Vec<ForeignKeyInfo>, String> {
+    let rows = sqlx::query(
+        "SELECT tc.constraint_name, \
+                kcu.table_schema, kcu.table_name, kcu.column_name, kcu.ordinal_position, \
+                ccu.table_schema AS target_schema, ccu.table_name AS target_table, ccu.column_name AS target_column \
+         FROM information_schema.table_constraints tc \
+         JOIN information_schema.key_column_usage kcu \
+           ON tc.constraint_name = kcu.constraint_name AND tc.table_schema = kcu.table_schema \
+         JOIN information_schema.constraint_column_usage ccu \
+           ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema \
+         WHERE tc.constraint_type = 'FOREIGN KEY' AND tc.table_schema = $1 \
+         ORDER BY tc.constraint_name, kcu.ordinal_position",
+    )
+    .bind(schema)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(rows
+        .iter()
+        .map(|r| ForeignKeyInfo {
+            constraint_name: r.get(0),
+            source_schema: r.get(1),
+            source_table: r.get(2),
+            source_column: r.get(3),
+            ordinal: r.get::<i32, _>(4),
+            target_schema: r.get(5),
+            target_table: r.get(6),
+            target_column: r.get(7),
+        })
+        .collect())
+}
+
+async fn mysql_foreign_keys(
+    pool: &sqlx::MySqlPool,
+    schema: &str,
+) -> Result<Vec<ForeignKeyInfo>, String> {
+    let rows = sqlx::query(
+        "SELECT constraint_name, table_schema, table_name, column_name, ordinal_position, \
+                referenced_table_schema, referenced_table_name, referenced_column_name \
+         FROM information_schema.key_column_usage \
+         WHERE referenced_table_name IS NOT NULL AND table_schema = ? \
+         ORDER BY constraint_name, ordinal_position",
+    )
+    .bind(schema)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(rows
+        .iter()
+        .map(|r| ForeignKeyInfo {
+            constraint_name: r.get(0),
+            source_schema: r.get(1),
+            source_table: r.get(2),
+            source_column: r.get(3),
+            ordinal: r.get::<i32, _>(4),
+            target_schema: r.get(5),
+            target_table: r.get(6),
+            target_column: r.get(7),
+        })
+        .collect())
+}
+
+async fn sqlite_foreign_keys(
+    pool: &sqlx::SqlitePool,
+    _schema: &str,
+) -> Result<Vec<ForeignKeyInfo>, String> {
+    // Enumerate tables, then query pragma_foreign_key_list per table.
+    let table_rows = sqlx::query(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'",
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    let mut result = Vec::new();
+    for tr in &table_rows {
+        let table_name: String = tr.get(0);
+        let sql = format!(
+            "SELECT id, seq, \"table\", \"from\", \"to\" FROM pragma_foreign_key_list('{}')",
+            table_name.replace('\'', "''")
+        );
+        let fk_rows = sqlx::query(&sql)
+            .fetch_all(pool)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        for fr in &fk_rows {
+            let fk_id: i32 = fr.get(0);
+            let seq: i32 = fr.get(1);
+            let target_table: String = fr.get(2);
+            let source_column: String = fr.get(3);
+            let target_column: Option<String> = fr.try_get(4).ok();
+            result.push(ForeignKeyInfo {
+                constraint_name: format!("{}__fk{}", table_name, fk_id),
+                source_schema: "main".to_string(),
+                source_table: table_name.clone(),
+                source_column,
+                ordinal: seq + 1,
+                target_schema: "main".to_string(),
+                target_table,
+                target_column: target_column.unwrap_or_default(),
+            });
+        }
+    }
+    Ok(result)
+}
+
+async fn mssql_foreign_keys(
+    pool: &bb8::Pool<bb8_tiberius::ConnectionManager>,
+    schema: &str,
+) -> Result<Vec<ForeignKeyInfo>, String> {
+    let mut conn = pool.get().await.map_err(|e| e.to_string())?;
+    let query = format!(
+        "SELECT fk.name, SCHEMA_NAME(fk.schema_id), OBJECT_NAME(fk.parent_object_id), pc.name, \
+                fkc.constraint_column_id, OBJECT_SCHEMA_NAME(fk.referenced_object_id), \
+                OBJECT_NAME(fk.referenced_object_id), rc.name \
+         FROM sys.foreign_keys fk \
+         JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id \
+         JOIN sys.columns pc ON fkc.parent_object_id = pc.object_id AND fkc.parent_column_id = pc.column_id \
+         JOIN sys.columns rc ON fkc.referenced_object_id = rc.object_id AND fkc.referenced_column_id = rc.column_id \
+         WHERE SCHEMA_NAME(fk.schema_id) = '{}' \
+         ORDER BY fk.name, fkc.constraint_column_id",
+        schema.replace('\'', "''")
+    );
+    let rows = conn
+        .simple_query(&query)
+        .await
+        .map_err(|e| e.to_string())?
+        .into_first_result()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(rows
+        .iter()
+        .filter_map(|r| {
+            let name = r.get::<&str, _>(0)?;
+            let src_schema = r.get::<&str, _>(1).unwrap_or(schema);
+            let src_table = r.get::<&str, _>(2)?;
+            let src_column = r.get::<&str, _>(3)?;
+            let ordinal = r.get::<i32, _>(4).unwrap_or(0);
+            let tgt_schema = r.get::<&str, _>(5).unwrap_or("dbo");
+            let tgt_table = r.get::<&str, _>(6)?;
+            let tgt_column = r.get::<&str, _>(7)?;
+            Some(ForeignKeyInfo {
+                constraint_name: name.to_string(),
+                source_schema: src_schema.to_string(),
+                source_table: src_table.to_string(),
+                source_column: src_column.to_string(),
+                ordinal,
+                target_schema: tgt_schema.to_string(),
+                target_table: tgt_table.to_string(),
+                target_column: tgt_column.to_string(),
+            })
+        })
+        .collect())
+}
+
+pub async fn list_foreign_keys(
+    pool: DbPool,
+    driver: &Driver,
+    schema: &str,
+) -> Result<Vec<ForeignKeyInfo>, String> {
+    match driver {
+        Driver::Postgres => pg_foreign_keys(get_pg_pool(&pool)?, schema).await,
+        Driver::Mysql => mysql_foreign_keys(get_mysql_pool(&pool)?, schema).await,
+        Driver::Sqlite => sqlite_foreign_keys(get_sqlite_pool(&pool)?, schema).await,
+        Driver::Mssql => mssql_foreign_keys(get_mssql_pool(&pool)?, schema).await,
+        Driver::Dbservice => Ok(Vec::new()),
     }
 }

--- a/src/components/EditorArea.tsx
+++ b/src/components/EditorArea.tsx
@@ -3,9 +3,11 @@ import { Columns2 } from "lucide-react";
 import type { editor as monacoEditor } from "monaco-editor";
 import { cn } from "../lib/utils";
 import { useAiStore } from "../stores/aiStore";
+import { useEditorStore } from "../stores/editorStore";
 import EditorTabs from "./EditorTabs";
 import SqlEditor from "./SqlEditor";
 import SplitEditorPane from "./SplitEditorPane";
+import SchemaDiagram from "./SchemaDiagram";
 import DiffPreview from "./DiffPreview";
 
 interface EditorAreaProps {
@@ -22,6 +24,8 @@ export default function EditorArea({ onExecute, onFormat }: EditorAreaProps) {
   const diffPreview = useAiStore((s) => s.diffPreview);
   const acceptDiff = useAiStore((s) => s.acceptDiffPreview);
   const rejectDiff = useAiStore((s) => s.closeDiffPreview);
+  const activeTab = useEditorStore((s) => s.tabs.find((t) => t.id === s.activeTabId));
+  const isDiagramTab = activeTab?.kind === "diagram";
 
   const toggleSplit = useCallback(() => {
     setSplit((prev) => !prev);
@@ -73,21 +77,25 @@ export default function EditorArea({ onExecute, onFormat }: EditorAreaProps) {
         <div className="flex-1">
           <EditorTabs />
         </div>
-        <button
-          onClick={toggleSplit}
-          className={cn(
-            "mr-1 rounded p-1 transition-colors",
-            split
-              ? "bg-primary/10 text-primary"
-              : "text-muted-foreground hover:bg-accent hover:text-foreground",
-          )}
-          title={split ? "Close split view" : "Split editor"}
-        >
-          <Columns2 size={14} />
-        </button>
+        {!isDiagramTab && (
+          <button
+            onClick={toggleSplit}
+            className={cn(
+              "mr-1 rounded p-1 transition-colors",
+              split
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+            title={split ? "Close split view" : "Split editor"}
+          >
+            <Columns2 size={14} />
+          </button>
+        )}
       </div>
 
-      {split ? (
+      {isDiagramTab && activeTab ? (
+        <SchemaDiagram tabId={activeTab.id} />
+      ) : split ? (
         <div ref={containerRef} className="flex flex-1 overflow-hidden">
           <div style={{ flex: `${splitRatio} 1 0%` }} className="flex min-w-0 flex-col overflow-hidden">
             <SqlEditor onExecute={onExecute} onFormat={onFormat} editorRefOut={primaryEditorRef} />

--- a/src/components/EditorTabs.tsx
+++ b/src/components/EditorTabs.tsx
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { Pin, Plus, X } from "lucide-react";
+import { ChevronDown, Network, Pin, Plus, SquarePen, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { buildSelectStatement, buildRoutineCallStatement } from "../lib/sqlGenerate";
 import { cn } from "../lib/utils";
@@ -22,6 +22,7 @@ export default function EditorTabs() {
     activeTabId,
     addTab,
     addTabWithContent,
+    addDiagramTab,
     closeTab,
     closeOtherTabs,
     closeTabsToRight,
@@ -39,6 +40,8 @@ export default function EditorTabs() {
   const [contextMenu, setContextMenu] = useState<TabContextMenu | null>(null);
   const contextRef = useRef<HTMLDivElement>(null);
   const [dragOver, setDragOver] = useState(false);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const addMenuRef = useRef<HTMLDivElement>(null);
 
   const commitRename = (id: string) => {
     const trimmed = editValue.trim();
@@ -65,6 +68,28 @@ export default function EditorTabs() {
       document.removeEventListener("keydown", onKeyDown);
     };
   }, [contextMenu, closeContextMenu]);
+
+  useEffect(() => {
+    if (!addMenuOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node)) {
+        setAddMenuOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setAddMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [addMenuOpen]);
+
+  const openSchemaDiagramTab = useCallback(() => {
+    addDiagramTab("Diagram", "", globalConnectionId ?? undefined);
+  }, [addDiagramTab, globalConnectionId]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     if (e.dataTransfer.types.includes("application/sqlai-table") || e.dataTransfer.types.includes("application/sqlai-routine")) {
@@ -270,20 +295,54 @@ export default function EditorTabs() {
       )}
       <div className="flex min-h-8 flex-wrap items-end gap-x-px gap-y-0.5 px-1 py-0.5">
         {unpinnedTabs.map(renderTab)}
-        <button
-          onClick={() => {
-            addTab();
-            // Assign current connection to the new tab
-            if (globalConnectionId) {
-              const newTab = useEditorStore.getState().getActiveTab();
-              if (newTab) setConnectionId(newTab.id, globalConnectionId);
-            }
-          }}
-          className="mb-0.5 ml-1 rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-          title="New tab (Ctrl+N)"
-        >
-          <Plus size={12} />
-        </button>
+        <div ref={addMenuRef} className="relative mb-0.5 ml-1 flex">
+          <button
+            onClick={() => {
+              addTab();
+              if (globalConnectionId) {
+                const newTab = useEditorStore.getState().getActiveTab();
+                if (newTab) setConnectionId(newTab.id, globalConnectionId);
+              }
+            }}
+            className="rounded-l rounded-r-none p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="New SQL tab (Ctrl+N)"
+          >
+            <Plus size={12} />
+          </button>
+          <button
+            onClick={() => setAddMenuOpen((v) => !v)}
+            className="rounded-l-none rounded-r border-l border-border/60 px-0.5 py-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="New tab options"
+          >
+            <ChevronDown size={10} />
+          </button>
+          {addMenuOpen && (
+            <div className="absolute left-0 top-full z-30 mt-0.5 min-w-44 rounded-md border border-border bg-background py-1 shadow-lg text-xs">
+              <button
+                onClick={() => {
+                  setAddMenuOpen(false);
+                  addTab();
+                  if (globalConnectionId) {
+                    const newTab = useEditorStore.getState().getActiveTab();
+                    if (newTab) setConnectionId(newTab.id, globalConnectionId);
+                  }
+                }}
+                className="flex w-full items-center gap-2 px-3 py-1.5 hover:bg-accent hover:text-accent-foreground"
+              >
+                <SquarePen size={11} /> New SQL tab
+              </button>
+              <button
+                onClick={() => {
+                  setAddMenuOpen(false);
+                  openSchemaDiagramTab();
+                }}
+                className="flex w-full items-center gap-2 px-3 py-1.5 hover:bg-accent hover:text-accent-foreground"
+              >
+                <Network size={11} /> New schema diagram
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       {contextMenu && (

--- a/src/components/SchemaDiagram.tsx
+++ b/src/components/SchemaDiagram.tsx
@@ -1,0 +1,1923 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  Download,
+  FileImage,
+  FileText,
+  FileType,
+  Grid3x3,
+  Key,
+  Link2,
+  Maximize,
+  MousePointer,
+  Palette,
+  Plus,
+  Minus,
+  Square,
+  Type as TypeIcon,
+  Slash,
+  RefreshCw,
+  Trash2,
+  X,
+} from "lucide-react";
+import { cn } from "../lib/utils";
+import { useEditorStore } from "../stores/editorStore";
+import { useConnectionStore } from "../stores/connectionStore";
+import type {
+  ColumnInfo,
+  ForeignKeyInfo,
+  TableInfo,
+} from "../types/schema";
+import {
+  snapValue,
+  type DiagramAnnotation,
+  type DiagramColorSettings,
+  type DiagramState,
+} from "../types/diagram";
+import {
+  COLUMN_HEIGHT,
+  HEADER_HEIGHT,
+  TABLE_WIDTH,
+  columnAnchor,
+  columnY,
+  tableHeight,
+} from "../lib/diagramLayout";
+import {
+  buildDrawioXml,
+  pngBlobToPdf,
+  saveBytesAs,
+  saveTextAs,
+  serializeSvg,
+  svgToPngBlob,
+} from "../lib/diagramExport";
+
+interface Props {
+  tabId: string;
+}
+
+type Tool = "select" | "add-rect" | "add-text" | "add-line";
+
+const DEFAULT_COLORS: DiagramColorSettings = {
+  tableHeader: "#3b82f6",
+  tableBorder: "#1e40af",
+  tableBody: "#ffffff",
+  pkColor: "#eab308",
+  fkColor: "#8b5cf6",
+  columnText: "#1f2937",
+  relationship: "#64748b",
+};
+
+const SWATCH_COLORS = [
+  "#3b82f6",
+  "#10b981",
+  "#8b5cf6",
+  "#ef4444",
+  "#f59e0b",
+  "#ec4899",
+  "#14b8a6",
+  "#6366f1",
+  "#64748b",
+];
+
+type LoadedSchema = {
+  tables: TableInfo[];
+  columns: Record<string, ColumnInfo[]>;
+  foreignKeys: ForeignKeyInfo[];
+};
+
+export default function SchemaDiagram({ tabId }: Props) {
+  const tab = useEditorStore((s) => s.tabs.find((t) => t.id === tabId));
+  const updateDiagram = useEditorStore((s) => s.updateDiagram);
+  const activeConnectionId = useConnectionStore((s) => s.activeConnectionId);
+  const connections = useConnectionStore((s) => s.connections);
+
+  const [loaded, setLoaded] = useState<LoadedSchema | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tool, setTool] = useState<Tool>("select");
+  const [selectedTable, setSelectedTable] = useState<string | null>(null);
+  const [selectedAnnotation, setSelectedAnnotation] = useState<string | null>(null);
+  const [colorPickerOpen, setColorPickerOpen] = useState(false);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const svgRef = useRef<SVGSVGElement>(null);
+  // Schemas whose FK set has been fetched; prevents duplicate fetches.
+  const fetchedFkSchemas = useRef<Set<string>>(new Set());
+
+  const connectionId = tab?.connectionId ?? activeConnectionId ?? undefined;
+  const connection = connections.find((c) => c.id === connectionId);
+
+  // --- Adding a single table (drop target) -----------------------------------
+  const addTable = useCallback(
+    async (schemaName: string, tableName: string, worldX: number, worldY: number) => {
+      if (!connectionId) {
+        setError("No connection selected");
+        return;
+      }
+      const key = `${schemaName}.${tableName}`;
+      setError(null);
+      setLoading(true);
+      try {
+        const cols = await invoke<ColumnInfo[]>("list_columns", {
+          connectionId,
+          schemaName,
+          tableName,
+        });
+
+        let newFks: ForeignKeyInfo[] = [];
+        if (!fetchedFkSchemas.current.has(schemaName)) {
+          try {
+            newFks = await invoke<ForeignKeyInfo[]>("list_foreign_keys", {
+              connectionId,
+              schemaName,
+            });
+          } catch {
+            newFks = [];
+          }
+          fetchedFkSchemas.current.add(schemaName);
+        }
+
+        setLoaded((prev) => {
+          const base = prev ?? { tables: [], columns: {}, foreignKeys: [] };
+          const already = base.tables.some(
+            (t) => t.schema === schemaName && t.name === tableName,
+          );
+          return {
+            tables: already
+              ? base.tables
+              : [
+                  ...base.tables,
+                  { schema: schemaName, name: tableName, tableType: "table" },
+                ],
+            columns: { ...base.columns, [key]: cols },
+            foreignKeys:
+              newFks.length > 0 ? [...base.foreignKeys, ...newFks] : base.foreignKeys,
+          };
+        });
+
+        updateDiagram(tabId, (d) => {
+          const existing = d.positions[key];
+          const snap = d.snapToGrid;
+          const x = snapValue(worldX, snap);
+          const y = snapValue(worldY, snap);
+          if (existing) {
+            // Already on the diagram — just move it to the drop point.
+            return {
+              ...d,
+              positions: { ...d.positions, [key]: { ...existing, x, y } },
+              loaded: true,
+            };
+          }
+          return {
+            ...d,
+            positions: { ...d.positions, [key]: { key, x, y } },
+            loaded: true,
+          };
+        });
+      } catch (e) {
+        setError(String(e));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [connectionId, tabId, updateDiagram],
+  );
+
+  // --- Refresh all currently-visible tables ----------------------------------
+  const refresh = useCallback(async () => {
+    if (!connectionId || !loaded || loaded.tables.length === 0) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const newColumns: Record<string, ColumnInfo[]> = {};
+      await Promise.all(
+        loaded.tables.map(async (t) => {
+          try {
+            newColumns[`${t.schema}.${t.name}`] = await invoke<ColumnInfo[]>("list_columns", {
+              connectionId,
+              schemaName: t.schema,
+              tableName: t.name,
+            });
+          } catch {
+            newColumns[`${t.schema}.${t.name}`] = loaded.columns[`${t.schema}.${t.name}`] ?? [];
+          }
+        }),
+      );
+      const schemas = new Set(loaded.tables.map((t) => t.schema));
+      const allFks: ForeignKeyInfo[] = [];
+      for (const s of schemas) {
+        try {
+          const fks = await invoke<ForeignKeyInfo[]>("list_foreign_keys", {
+            connectionId,
+            schemaName: s,
+          });
+          allFks.push(...fks);
+        } catch {
+          // ignore
+        }
+      }
+      fetchedFkSchemas.current = schemas;
+      setLoaded({ tables: loaded.tables, columns: newColumns, foreignKeys: allFks });
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [connectionId, loaded]);
+
+  // Delete / Backspace removes the selected annotation, or hides the selected table.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Delete" && e.key !== "Backspace") return;
+      const target = e.target as HTMLElement | null;
+      if (target && /^(INPUT|TEXTAREA|SELECT)$/i.test(target.tagName)) return;
+      if (target && target.isContentEditable) return;
+      if (selectedAnnotation) {
+        e.preventDefault();
+        updateDiagram(tabId, (d) => ({
+          ...d,
+          annotations: d.annotations.filter((a) => a.id !== selectedAnnotation),
+        }));
+        setSelectedAnnotation(null);
+      } else if (selectedTable) {
+        e.preventDefault();
+        updateDiagram(tabId, (d) => {
+          const { [selectedTable]: _removed, ...rest } = d.positions;
+          void _removed;
+          return { ...d, positions: rest };
+        });
+        setSelectedTable(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedAnnotation, selectedTable, tabId, updateDiagram]);
+
+  if (!tab || !tab.diagram) {
+    return <div className="p-4 text-sm text-muted-foreground">Tab not found</div>;
+  }
+
+  const diagram = tab.diagram;
+  const colors = { ...DEFAULT_COLORS, ...(diagram.colors ?? {}) };
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden bg-background">
+      <Toolbar
+        diagram={diagram}
+        loading={loading}
+        tool={tool}
+        onTool={setTool}
+        connection={connection?.name}
+        tableCount={loaded?.tables.length ?? 0}
+        onRefresh={refresh}
+        onZoom={(delta) =>
+          updateDiagram(tabId, (d) => ({
+            ...d,
+            zoom: Math.max(0.2, Math.min(3, d.zoom + delta)),
+          }))
+        }
+        onResetView={() =>
+          updateDiagram(tabId, (d) => ({ ...d, zoom: 1, panX: 0, panY: 0 }))
+        }
+        onFit={() =>
+          fitToContent(svgRef.current, diagram, loaded, (updater) =>
+            updateDiagram(tabId, updater),
+          )
+        }
+        onToggleSnap={() =>
+          updateDiagram(tabId, (d) => ({ ...d, snapToGrid: !d.snapToGrid }))
+        }
+        colorPickerOpen={colorPickerOpen}
+        onToggleColors={() => setColorPickerOpen((v) => !v)}
+        exportMenuOpen={exportMenuOpen}
+        onToggleExport={() => setExportMenuOpen((v) => !v)}
+        onExport={async (kind) => {
+          setExportMenuOpen(false);
+          await handleExport(kind, svgRef.current, diagram, loaded);
+        }}
+      />
+      {colorPickerOpen && (
+        <ColorPicker
+          colors={colors}
+          onChange={(patch) =>
+            updateDiagram(tabId, (d) => ({
+              ...d,
+              colors: { ...(d.colors ?? {}), ...patch },
+            }))
+          }
+          onClose={() => setColorPickerOpen(false)}
+        />
+      )}
+      {error && (
+        <div className="border-b border-destructive/40 bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Canvas
+        svgRef={svgRef}
+        diagram={diagram}
+        loaded={loaded}
+        colors={colors}
+        tool={tool}
+        onResetTool={() => setTool("select")}
+        onDropTable={(schemaName, tableName, worldX, worldY) =>
+          addTable(schemaName, tableName, worldX, worldY)
+        }
+        selectedTable={selectedTable}
+        selectedAnnotation={selectedAnnotation}
+        onSelectTable={(k) => {
+          setSelectedTable(k);
+          setSelectedAnnotation(null);
+        }}
+        onSelectAnnotation={(id) => {
+          setSelectedAnnotation(id);
+          setSelectedTable(null);
+        }}
+        onPan={(dx, dy) =>
+          updateDiagram(tabId, (d) => ({ ...d, panX: d.panX + dx, panY: d.panY + dy }))
+        }
+        onZoom={(delta, cx, cy) =>
+          updateDiagram(tabId, (d) => {
+            const next = Math.max(0.2, Math.min(3, d.zoom + delta));
+            const ratio = next / d.zoom;
+            // Zoom towards cursor
+            const panX = cx - (cx - d.panX) * ratio;
+            const panY = cy - (cy - d.panY) * ratio;
+            return { ...d, zoom: next, panX, panY };
+          })
+        }
+        onSetTablePos={(key, x, y) =>
+          updateDiagram(tabId, (d) => {
+            const pos = d.positions[key];
+            if (!pos) return d;
+            return {
+              ...d,
+              positions: { ...d.positions, [key]: { ...pos, x, y } },
+            };
+          })
+        }
+        onAddAnnotation={(ann) =>
+          updateDiagram(tabId, (d) => ({
+            ...d,
+            annotations: [...d.annotations, ann],
+          }))
+        }
+        onUpdateAnnotation={(id, patch) =>
+          updateDiagram(tabId, (d) => ({
+            ...d,
+            annotations: d.annotations.map((a) => (a.id === id ? { ...a, ...patch } : a)),
+          }))
+        }
+        onSetTableColor={(key, color) =>
+          updateDiagram(tabId, (d) => {
+            const pos = d.positions[key];
+            if (!pos) return d;
+            return {
+              ...d,
+              positions: { ...d.positions, [key]: { ...pos, color } },
+            };
+          })
+        }
+      />
+
+      {selectedAnnotation && (
+        <AnnotationInspector
+          annotation={diagram.annotations.find((a) => a.id === selectedAnnotation)!}
+          onChange={(patch) =>
+            updateDiagram(tabId, (d) => ({
+              ...d,
+              annotations: d.annotations.map((a) =>
+                a.id === selectedAnnotation ? { ...a, ...patch } : a,
+              ),
+            }))
+          }
+          onDelete={() => {
+            updateDiagram(tabId, (d) => ({
+              ...d,
+              annotations: d.annotations.filter((a) => a.id !== selectedAnnotation),
+            }));
+            setSelectedAnnotation(null);
+          }}
+          onClose={() => setSelectedAnnotation(null)}
+        />
+      )}
+
+      {selectedTable && (
+        <TableInspector
+          tableKey={selectedTable}
+          color={diagram.positions[selectedTable]?.color}
+          onSetColor={(color) => {
+            updateDiagram(tabId, (d) => {
+              const pos = d.positions[selectedTable];
+              if (!pos) return d;
+              return {
+                ...d,
+                positions: { ...d.positions, [selectedTable]: { ...pos, color } },
+              };
+            });
+          }}
+          onClose={() => setSelectedTable(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Toolbar
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface ToolbarProps {
+  diagram: DiagramState;
+  loading: boolean;
+  tool: Tool;
+  onTool: (t: Tool) => void;
+  connection?: string;
+  tableCount: number;
+  onRefresh: () => void;
+  onZoom: (delta: number) => void;
+  onResetView: () => void;
+  onFit: () => void;
+  onToggleSnap: () => void;
+  colorPickerOpen: boolean;
+  onToggleColors: () => void;
+  exportMenuOpen: boolean;
+  onToggleExport: () => void;
+  onExport: (kind: "png" | "svg" | "pdf" | "drawio") => void;
+}
+
+function Toolbar({
+  diagram,
+  loading,
+  tool,
+  onTool,
+  connection,
+  tableCount,
+  onRefresh,
+  onZoom,
+  onResetView,
+  onFit,
+  onToggleSnap,
+  colorPickerOpen,
+  onToggleColors,
+  exportMenuOpen,
+  onToggleExport,
+  onExport,
+}: ToolbarProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-border bg-muted/20 px-2 py-1.5 text-xs">
+      <span className="text-muted-foreground">
+        {connection ? `${connection} · ` : ""}Diagram
+      </span>
+      <span className="text-[10px] text-muted-foreground/70">
+        {tableCount} {tableCount === 1 ? "table" : "tables"}
+      </span>
+      <button
+        onClick={onRefresh}
+        disabled={loading || tableCount === 0}
+        className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-40"
+        title="Reload columns & foreign keys"
+      >
+        <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
+      </button>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      <ToolBtn active={tool === "select"} onClick={() => onTool("select")} title="Select / drag tables (V)">
+        <MousePointer size={12} />
+      </ToolBtn>
+      <ToolBtn active={tool === "add-rect"} onClick={() => onTool("add-rect")} title="Draw rectangle (R)">
+        <Square size={12} />
+      </ToolBtn>
+      <ToolBtn active={tool === "add-text"} onClick={() => onTool("add-text")} title="Add text (T)">
+        <TypeIcon size={12} />
+      </ToolBtn>
+      <ToolBtn active={tool === "add-line"} onClick={() => onTool("add-line")} title="Draw line (L)">
+        <Slash size={12} />
+      </ToolBtn>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      <button
+        onClick={() => onZoom(-0.1)}
+        className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Zoom out"
+      >
+        <Minus size={12} />
+      </button>
+      <span className="min-w-10 text-center text-[10px] text-muted-foreground">
+        {Math.round(diagram.zoom * 100)}%
+      </span>
+      <button
+        onClick={() => onZoom(0.1)}
+        className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Zoom in"
+      >
+        <Plus size={12} />
+      </button>
+      <button
+        onClick={onFit}
+        className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Fit to content"
+      >
+        <Maximize size={12} />
+      </button>
+      <button
+        onClick={onResetView}
+        className="rounded px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-foreground"
+        title="Reset view"
+      >
+        Reset
+      </button>
+
+      <div className="mx-1 h-4 w-px bg-border" />
+
+      <button
+        onClick={onToggleSnap}
+        className={cn(
+          "flex items-center gap-1 rounded px-2 py-1 text-[10px]",
+          diagram.snapToGrid
+            ? "bg-primary/15 text-primary"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
+        )}
+        title={diagram.snapToGrid ? "Snap to grid: on" : "Snap to grid: off"}
+      >
+        <Grid3x3 size={12} /> Snap
+      </button>
+
+      <div className="ml-auto flex items-center gap-1">
+        <button
+          onClick={onToggleColors}
+          className={cn(
+            "flex items-center gap-1 rounded px-2 py-1 text-[10px]",
+            colorPickerOpen
+              ? "bg-primary/10 text-primary"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground",
+          )}
+        >
+          <Palette size={12} /> Colors
+        </button>
+        <div className="relative">
+          <button
+            onClick={onToggleExport}
+            className={cn(
+              "flex items-center gap-1 rounded px-2 py-1 text-[10px]",
+              exportMenuOpen
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+          >
+            <Download size={12} /> Export
+          </button>
+          {exportMenuOpen && (
+            <div className="absolute right-0 top-full z-30 mt-1 min-w-40 rounded-md border border-border bg-background py-1 shadow-lg">
+              <ExportItem icon={<FileImage size={12} />} label="PNG image" onClick={() => onExport("png")} />
+              <ExportItem icon={<FileImage size={12} />} label="SVG image" onClick={() => onExport("svg")} />
+              <ExportItem icon={<FileText size={12} />} label="PDF document" onClick={() => onExport("pdf")} />
+              <ExportItem icon={<FileType size={12} />} label="drawio file" onClick={() => onExport("drawio")} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ToolBtn({
+  active,
+  onClick,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "rounded p-1",
+        active
+          ? "bg-primary/15 text-primary"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ExportItem({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Canvas
+// ──────────────────────────────────────────────────────────────────────────────
+
+interface CanvasProps {
+  svgRef: React.RefObject<SVGSVGElement | null>;
+  diagram: DiagramState;
+  loaded: LoadedSchema | null;
+  colors: DiagramColorSettings;
+  tool: Tool;
+  onResetTool: () => void;
+  onDropTable: (schemaName: string, tableName: string, worldX: number, worldY: number) => void;
+  selectedTable: string | null;
+  selectedAnnotation: string | null;
+  onSelectTable: (k: string | null) => void;
+  onSelectAnnotation: (id: string | null) => void;
+  onPan: (dx: number, dy: number) => void;
+  onZoom: (delta: number, cx: number, cy: number) => void;
+  onSetTablePos: (key: string, x: number, y: number) => void;
+  onAddAnnotation: (ann: DiagramAnnotation) => void;
+  onUpdateAnnotation: (id: string, patch: Partial<DiagramAnnotation>) => void;
+  onSetTableColor: (key: string, color: string) => void;
+}
+
+function Canvas({
+  svgRef,
+  diagram,
+  loaded,
+  colors,
+  tool,
+  onResetTool,
+  onDropTable,
+  selectedTable,
+  selectedAnnotation,
+  onSelectTable,
+  onSelectAnnotation,
+  onPan,
+  onZoom,
+  onSetTablePos,
+  onAddAnnotation,
+  onUpdateAnnotation,
+}: CanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [draftAnn, setDraftAnn] = useState<DiagramAnnotation | null>(null);
+  const [dropOver, setDropOver] = useState(false);
+  const snap = diagram.snapToGrid;
+  const dragRef = useRef<
+    | null
+    | { kind: "pan"; startX: number; startY: number }
+    | {
+        kind: "table";
+        key: string;
+        startClientX: number;
+        startClientY: number;
+        startPosX: number;
+        startPosY: number;
+      }
+    | { kind: "draw"; startX: number; startY: number }
+  >(null);
+
+  /** Convert client (mouse) coords to canvas world coords. */
+  const toWorld = useCallback(
+    (clientX: number, clientY: number) => {
+      const el = containerRef.current;
+      if (!el) return { x: 0, y: 0 };
+      const rect = el.getBoundingClientRect();
+      const localX = clientX - rect.left;
+      const localY = clientY - rect.top;
+      return {
+        x: (localX - diagram.panX) / diagram.zoom,
+        y: (localY - diagram.panY) / diagram.zoom,
+      };
+    },
+    [diagram.panX, diagram.panY, diagram.zoom],
+  );
+
+  // Non-passive wheel listener so we can preventDefault and zoom to cursor.
+  // Wheel-to-zoom is always active; Shift+wheel pans horizontally, plain Shift-less
+  // scrolling with the Ctrl modifier still works because we preventDefault in all cases.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handler = (e: WheelEvent) => {
+      e.preventDefault();
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      // Normalize deltaY across DOM_DELTA_PIXEL (0), DOM_DELTA_LINE (1), DOM_DELTA_PAGE (2).
+      const unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? rect.height : 1;
+      const scaledDelta = e.deltaY * unit;
+      // Clamp per-tick to avoid huge jumps from high-resolution touchpad wheels.
+      const clamped = Math.max(-120, Math.min(120, scaledDelta));
+      const delta = -clamped * 0.0035;
+      onZoom(delta, cx, cy);
+    };
+    el.addEventListener("wheel", handler, { passive: false });
+    return () => el.removeEventListener("wheel", handler);
+  }, [onZoom]);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.button !== 0) return;
+      if (tool === "select") {
+        dragRef.current = { kind: "pan", startX: e.clientX, startY: e.clientY };
+        onSelectTable(null);
+        onSelectAnnotation(null);
+      } else {
+        const w = toWorld(e.clientX, e.clientY);
+        const id = crypto.randomUUID();
+        let ann: DiagramAnnotation;
+        if (tool === "add-rect") {
+          ann = {
+            id,
+            shape: "rect",
+            x: w.x,
+            y: w.y,
+            width: 1,
+            height: 1,
+            color: colors.relationship,
+            fill: "rgba(59,130,246,0.1)",
+          };
+        } else if (tool === "add-line") {
+          ann = {
+            id,
+            shape: "line",
+            x: w.x,
+            y: w.y,
+            x2: w.x,
+            y2: w.y,
+            color: colors.relationship,
+            strokeWidth: 2,
+          };
+        } else {
+          ann = {
+            id,
+            shape: "text",
+            x: w.x,
+            y: w.y,
+            width: 160,
+            height: 24,
+            text: "Text",
+            color: colors.columnText,
+            fontSize: 14,
+          };
+          onAddAnnotation(ann);
+          onSelectAnnotation(id);
+          onResetTool();
+          return;
+        }
+        setDraftAnn(ann);
+        dragRef.current = { kind: "draw", startX: e.clientX, startY: e.clientY };
+      }
+    },
+    [tool, toWorld, onSelectTable, onSelectAnnotation, onAddAnnotation, onResetTool, colors],
+  );
+
+  const onMouseMove = useCallback(
+    (e: MouseEvent) => {
+      const drag = dragRef.current;
+      if (!drag) return;
+      if (drag.kind === "pan") {
+        const dx = e.clientX - drag.startX;
+        const dy = e.clientY - drag.startY;
+        if (dx !== 0 || dy !== 0) {
+          onPan(dx, dy);
+          dragRef.current = { ...drag, startX: e.clientX, startY: e.clientY };
+        }
+      } else if (drag.kind === "table") {
+        const dx = (e.clientX - drag.startClientX) / diagram.zoom;
+        const dy = (e.clientY - drag.startClientY) / diagram.zoom;
+        const nx = snapValue(drag.startPosX + dx, snap);
+        const ny = snapValue(drag.startPosY + dy, snap);
+        onSetTablePos(drag.key, nx, ny);
+      } else if (drag.kind === "draw" && draftAnn) {
+        const w = toWorld(e.clientX, e.clientY);
+        const sx = snapValue(w.x, snap);
+        const sy = snapValue(w.y, snap);
+        if (draftAnn.shape === "rect") {
+          setDraftAnn({
+            ...draftAnn,
+            x: Math.min(draftAnn.x, sx),
+            y: Math.min(draftAnn.y, sy),
+            width: Math.abs(sx - draftAnn.x) || 1,
+            height: Math.abs(sy - draftAnn.y) || 1,
+          });
+        } else if (draftAnn.shape === "line") {
+          setDraftAnn({ ...draftAnn, x2: sx, y2: sy });
+        }
+      }
+    },
+    [diagram.zoom, draftAnn, onPan, onSetTablePos, toWorld, snap],
+  );
+
+  const onMouseUp = useCallback(() => {
+    const drag = dragRef.current;
+    dragRef.current = null;
+    if (drag?.kind === "draw" && draftAnn) {
+      // Commit the draft if it has size
+      const ok =
+        (draftAnn.shape === "rect" && (draftAnn.width ?? 0) > 4 && (draftAnn.height ?? 0) > 4) ||
+        (draftAnn.shape === "line" &&
+          (Math.abs((draftAnn.x2 ?? 0) - draftAnn.x) > 4 ||
+            Math.abs((draftAnn.y2 ?? 0) - draftAnn.y) > 4));
+      if (ok) {
+        onAddAnnotation(draftAnn);
+        onSelectAnnotation(draftAnn.id);
+      }
+      setDraftAnn(null);
+      onResetTool();
+    }
+  }, [draftAnn, onAddAnnotation, onSelectAnnotation, onResetTool]);
+
+  useEffect(() => {
+    const move = (e: MouseEvent) => onMouseMove(e);
+    const up = () => onMouseUp();
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+    return () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+    };
+  }, [onMouseMove, onMouseUp]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "relative flex-1 overflow-hidden bg-muted/10",
+        dropOver && "ring-2 ring-inset ring-primary/40",
+      )}
+      style={{ cursor: tool === "select" ? "grab" : "crosshair" }}
+      onMouseDown={onMouseDown}
+      onDragOver={(e) => {
+        if (!e.dataTransfer.types.includes("application/sqlai-table")) return;
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "copy";
+        setDropOver(true);
+      }}
+      onDragLeave={(e) => {
+        // Only clear when leaving the container itself, not inner children.
+        if (e.currentTarget === e.target) setDropOver(false);
+      }}
+      onDrop={(e) => {
+        setDropOver(false);
+        const raw = e.dataTransfer.getData("application/sqlai-table");
+        if (!raw) return;
+        e.preventDefault();
+        try {
+          const { schemaName, tableName } = JSON.parse(raw) as {
+            schemaName: string;
+            tableName: string;
+          };
+          const w = toWorld(e.clientX, e.clientY);
+          onDropTable(schemaName, tableName, w.x, w.y);
+        } catch {
+          // ignore malformed payload
+        }
+      }}
+    >
+      {/* Background dot grid */}
+      <div
+        className="pointer-events-none absolute inset-0 opacity-60"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle, var(--color-muted-foreground) 1px, transparent 1px)",
+          backgroundSize: `${20 * diagram.zoom}px ${20 * diagram.zoom}px`,
+          backgroundPosition: `${diagram.panX}px ${diagram.panY}px`,
+          opacity: 0.15,
+        }}
+      />
+
+      <svg
+        ref={svgRef}
+        className="absolute inset-0 h-full w-full"
+      >
+        <defs>
+          <marker
+            id="arrowhead-fk"
+            viewBox="0 0 12 12"
+            refX="10"
+            refY="6"
+            markerWidth="10"
+            markerHeight="10"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 12 6 L 0 12 z" fill={colors.relationship} />
+          </marker>
+        </defs>
+        <g
+          transform={`translate(${diagram.panX} ${diagram.panY}) scale(${diagram.zoom})`}
+        >
+          {/* Annotations behind tables */}
+          {diagram.annotations
+            .filter((a) => a.shape !== "line")
+            .map((a) => (
+              <AnnotationNode
+                key={a.id}
+                annotation={a}
+                selected={selectedAnnotation === a.id}
+                onSelect={() => onSelectAnnotation(a.id)}
+                onStartDrag={(e) => {
+                  if (tool !== "select") return;
+                  e.stopPropagation();
+                  dragRef.current = {
+                    kind: "draw",
+                    startX: e.clientX,
+                    startY: e.clientY,
+                  };
+                  // Use a custom ann-move drag by reusing draftAnn logic:
+                  // Simpler: move via direct state update per mousemove.
+                  const startWorld = toWorld(e.clientX, e.clientY);
+                  const origX = a.x;
+                  const origY = a.y;
+                  const move = (ev: MouseEvent) => {
+                    const w = toWorld(ev.clientX, ev.clientY);
+                    onUpdateAnnotation(a.id, {
+                      x: snapValue(origX + (w.x - startWorld.x), snap),
+                      y: snapValue(origY + (w.y - startWorld.y), snap),
+                    });
+                  };
+                  const up = () => {
+                    window.removeEventListener("mousemove", move);
+                    window.removeEventListener("mouseup", up);
+                  };
+                  window.addEventListener("mousemove", move);
+                  window.addEventListener("mouseup", up);
+                }}
+              />
+            ))}
+
+          {/* FK relationships */}
+          {loaded && <Relationships loaded={loaded} diagram={diagram} color={colors.relationship} />}
+
+          {/* Tables */}
+          {loaded?.tables.map((t) => {
+            const key = `${t.schema}.${t.name}`;
+            const pos = diagram.positions[key];
+            if (!pos) return null;
+            const cols = loaded.columns[key] ?? [];
+            return (
+              <TableNode
+                key={key}
+                tableKey={key}
+                name={t.name}
+                columns={cols}
+                x={pos.x}
+                y={pos.y}
+                color={pos.color}
+                colors={colors}
+                foreignKeys={loaded.foreignKeys}
+                selected={selectedTable === key}
+                onSelect={() => onSelectTable(key)}
+                onStartDrag={(e) => {
+                  e.stopPropagation();
+                  dragRef.current = {
+                    kind: "table",
+                    key,
+                    startClientX: e.clientX,
+                    startClientY: e.clientY,
+                    startPosX: pos.x,
+                    startPosY: pos.y,
+                  };
+                }}
+              />
+            );
+          })}
+
+          {/* Line annotations in front */}
+          {diagram.annotations
+            .filter((a) => a.shape === "line")
+            .map((a) => (
+              <AnnotationNode
+                key={a.id}
+                annotation={a}
+                selected={selectedAnnotation === a.id}
+                onSelect={() => onSelectAnnotation(a.id)}
+                onStartDrag={(e) => {
+                  if (tool !== "select") return;
+                  e.stopPropagation();
+                  const startWorld = toWorld(e.clientX, e.clientY);
+                  const origX = a.x;
+                  const origY = a.y;
+                  const origX2 = a.x2 ?? a.x;
+                  const origY2 = a.y2 ?? a.y;
+                  const move = (ev: MouseEvent) => {
+                    const w = toWorld(ev.clientX, ev.clientY);
+                    const dx = w.x - startWorld.x;
+                    const dy = w.y - startWorld.y;
+                    onUpdateAnnotation(a.id, {
+                      x: snapValue(origX + dx, snap),
+                      y: snapValue(origY + dy, snap),
+                      x2: snapValue(origX2 + dx, snap),
+                      y2: snapValue(origY2 + dy, snap),
+                    });
+                  };
+                  const up = () => {
+                    window.removeEventListener("mousemove", move);
+                    window.removeEventListener("mouseup", up);
+                  };
+                  window.addEventListener("mousemove", move);
+                  window.addEventListener("mouseup", up);
+                }}
+              />
+            ))}
+
+          {/* Draft annotation */}
+          {draftAnn && (
+            <AnnotationNode
+              annotation={draftAnn}
+              selected={false}
+              onSelect={() => {}}
+              onStartDrag={() => {}}
+            />
+          )}
+
+          {/* Resize handles for selected annotation */}
+          {(() => {
+            if (!selectedAnnotation) return null;
+            const ann = diagram.annotations.find((a) => a.id === selectedAnnotation);
+            if (!ann) return null;
+            return (
+              <SelectionHandles
+                annotation={ann}
+                zoom={diagram.zoom}
+                snap={snap}
+                toWorld={toWorld}
+                onUpdate={onUpdateAnnotation}
+              />
+            );
+          })()}
+        </g>
+      </svg>
+
+      {(!loaded || loaded.tables.length === 0) && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="pointer-events-none rounded-md border border-dashed border-border bg-background/70 px-4 py-3 text-center text-xs text-muted-foreground">
+            Drag tables from the schema tree to add them to the diagram.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Resize handles
+// ──────────────────────────────────────────────────────────────────────────────
+
+const MIN_RECT_SIZE = 8;
+const MIN_TEXT_WIDTH = 20;
+
+function Handle({
+  cx,
+  cy,
+  size,
+  strokeW,
+  cursor,
+  onDown,
+  round,
+}: {
+  cx: number;
+  cy: number;
+  size: number;
+  strokeW: number;
+  cursor: string;
+  round?: boolean;
+  onDown: (e: React.MouseEvent) => void;
+}) {
+  const half = size / 2;
+  return round ? (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={half}
+      fill="#ffffff"
+      stroke="#2563eb"
+      strokeWidth={strokeW}
+      style={{ cursor }}
+      onMouseDown={onDown}
+    />
+  ) : (
+    <rect
+      x={cx - half}
+      y={cy - half}
+      width={size}
+      height={size}
+      fill="#ffffff"
+      stroke="#2563eb"
+      strokeWidth={strokeW}
+      style={{ cursor }}
+      onMouseDown={onDown}
+    />
+  );
+}
+
+function SelectionHandles({
+  annotation,
+  zoom,
+  snap,
+  toWorld,
+  onUpdate,
+}: {
+  annotation: DiagramAnnotation;
+  zoom: number;
+  snap: boolean | undefined;
+  toWorld: (clientX: number, clientY: number) => { x: number; y: number };
+  onUpdate: (id: string, patch: Partial<DiagramAnnotation>) => void;
+}) {
+  const size = 8 / zoom;
+  const strokeW = 1 / zoom;
+
+  const startResize = (
+    e: React.MouseEvent,
+    compute: (wx: number, wy: number) => Partial<DiagramAnnotation>,
+  ) => {
+    e.stopPropagation();
+    e.preventDefault();
+    const move = (ev: MouseEvent) => {
+      const w = toWorld(ev.clientX, ev.clientY);
+      onUpdate(annotation.id, compute(snapValue(w.x, snap), snapValue(w.y, snap)));
+    };
+    const up = () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+    };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+  };
+
+  if (annotation.shape === "rect") {
+    const x = annotation.x;
+    const y = annotation.y;
+    const w = annotation.width ?? 100;
+    const h = annotation.height ?? 60;
+    const right = x + w;
+    const bottom = y + h;
+    return (
+      <g>
+        {/* Corners */}
+        <Handle size={size} strokeW={strokeW}
+          cx={x}
+          cy={y}
+          cursor="nwse-resize"
+          onDown={(e) =>
+            startResize(e, (wx, wy) => {
+              const nx = Math.min(wx, right - MIN_RECT_SIZE);
+              const ny = Math.min(wy, bottom - MIN_RECT_SIZE);
+              return { x: nx, y: ny, width: right - nx, height: bottom - ny };
+            })
+          }
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={right}
+          cy={y}
+          cursor="nesw-resize"
+          onDown={(e) =>
+            startResize(e, (wx, wy) => {
+              const ny = Math.min(wy, bottom - MIN_RECT_SIZE);
+              return {
+                y: ny,
+                width: Math.max(MIN_RECT_SIZE, wx - x),
+                height: bottom - ny,
+              };
+            })
+          }
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={x}
+          cy={bottom}
+          cursor="nesw-resize"
+          onDown={(e) =>
+            startResize(e, (wx, wy) => {
+              const nx = Math.min(wx, right - MIN_RECT_SIZE);
+              return {
+                x: nx,
+                width: right - nx,
+                height: Math.max(MIN_RECT_SIZE, wy - y),
+              };
+            })
+          }
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={right}
+          cy={bottom}
+          cursor="nwse-resize"
+          onDown={(e) =>
+            startResize(e, (wx, wy) => ({
+              width: Math.max(MIN_RECT_SIZE, wx - x),
+              height: Math.max(MIN_RECT_SIZE, wy - y),
+            }))
+          }
+        />
+        {/* Edges */}
+        <Handle size={size} strokeW={strokeW}
+          cx={x + w / 2}
+          cy={y}
+          cursor="ns-resize"
+          onDown={(e) =>
+            startResize(e, (_wx, wy) => {
+              const ny = Math.min(wy, bottom - MIN_RECT_SIZE);
+              return { y: ny, height: bottom - ny };
+            })
+          }
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={x + w / 2}
+          cy={bottom}
+          cursor="ns-resize"
+          onDown={(e) =>
+            startResize(e, (_wx, wy) => ({
+              height: Math.max(MIN_RECT_SIZE, wy - y),
+            }))
+          }
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={x}
+          cy={y + h / 2}
+          cursor="ew-resize"
+          onDown={(e) =>
+            startResize(e, (wx) => {
+              const nx = Math.min(wx, right - MIN_RECT_SIZE);
+              return { x: nx, width: right - nx };
+            })
+          }
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={right}
+          cy={y + h / 2}
+          cursor="ew-resize"
+          onDown={(e) =>
+            startResize(e, (wx) => ({
+              width: Math.max(MIN_RECT_SIZE, wx - x),
+            }))
+          }
+        />
+      </g>
+    );
+  }
+
+  if (annotation.shape === "line") {
+    const x1 = annotation.x;
+    const y1 = annotation.y;
+    const x2 = annotation.x2 ?? x1;
+    const y2 = annotation.y2 ?? y1;
+    return (
+      <g>
+        <Handle size={size} strokeW={strokeW}
+          cx={x1}
+          cy={y1}
+          cursor="move"
+          round
+          onDown={(e) => startResize(e, (wx, wy) => ({ x: wx, y: wy }))}
+        />
+        <Handle size={size} strokeW={strokeW}
+          cx={x2}
+          cy={y2}
+          cursor="move"
+          round
+          onDown={(e) => startResize(e, (wx, wy) => ({ x2: wx, y2: wy }))}
+        />
+      </g>
+    );
+  }
+
+  if (annotation.shape === "text") {
+    const x = annotation.x;
+    const y = annotation.y;
+    const w = annotation.width ?? 160;
+    const h = annotation.height ?? 24;
+    const fontSize = annotation.fontSize ?? 14;
+    return (
+      <g>
+        {/* Right edge: resize width only */}
+        <Handle size={size} strokeW={strokeW}
+          cx={x + w}
+          cy={y + h / 2}
+          cursor="ew-resize"
+          onDown={(e) =>
+            startResize(e, (wx) => ({
+              width: Math.max(MIN_TEXT_WIDTH, wx - x),
+            }))
+          }
+        />
+        {/* Bottom-right corner: scale font size proportional to height */}
+        <Handle size={size} strokeW={strokeW}
+          cx={x + w}
+          cy={y + h}
+          cursor="nwse-resize"
+          onDown={(e) =>
+            startResize(e, (wx, wy) => {
+              const newW = Math.max(MIN_TEXT_WIDTH, wx - x);
+              const newH = Math.max(10, wy - y);
+              const scale = newH / h;
+              return {
+                width: newW,
+                height: newH,
+                fontSize: Math.max(8, Math.round(fontSize * scale)),
+              };
+            })
+          }
+        />
+      </g>
+    );
+  }
+
+  return null;
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ──────────────────────────────────────────────────────────────────────────────
+
+function TableNode({
+  tableKey,
+  name,
+  columns,
+  x,
+  y,
+  color,
+  colors,
+  foreignKeys,
+  selected,
+  onSelect,
+  onStartDrag,
+}: {
+  tableKey: string;
+  name: string;
+  columns: ColumnInfo[];
+  x: number;
+  y: number;
+  color?: string;
+  colors: DiagramColorSettings;
+  foreignKeys: ForeignKeyInfo[];
+  selected: boolean;
+  onSelect: () => void;
+  onStartDrag: (e: React.MouseEvent) => void;
+}) {
+  const h = tableHeight(columns.length);
+  const headerColor = color ?? colors.tableHeader;
+  const dotIdx = tableKey.indexOf(".");
+  const schema = dotIdx >= 0 ? tableKey.slice(0, dotIdx) : "";
+  const fkCols = new Set<string>();
+  for (const fk of foreignKeys) {
+    if (fk.sourceSchema === schema && fk.sourceTable === name) {
+      fkCols.add(fk.sourceColumn);
+    }
+  }
+
+  return (
+    <g
+      transform={`translate(${x} ${y})`}
+      onMouseDown={(e) => {
+        onSelect();
+        onStartDrag(e);
+      }}
+      style={{ cursor: "move" }}
+    >
+      <rect
+        width={TABLE_WIDTH}
+        height={h}
+        rx={6}
+        ry={6}
+        fill={colors.tableBody}
+        stroke={selected ? "#2563eb" : colors.tableBorder}
+        strokeWidth={selected ? 2 : 1}
+      />
+      <rect
+        width={TABLE_WIDTH}
+        height={HEADER_HEIGHT}
+        rx={6}
+        ry={6}
+        fill={headerColor}
+      />
+      {/* Clip bottom corners of header */}
+      <rect y={HEADER_HEIGHT - 6} width={TABLE_WIDTH} height={6} fill={headerColor} />
+      <text x={10} y={HEADER_HEIGHT / 2} dy="0.35em" fill="#ffffff" fontSize={13} fontWeight={600}>
+        {schema ? (
+          <>
+            <tspan fillOpacity={0.7} fontWeight={400}>
+              {schema}.
+            </tspan>
+            <tspan>{name}</tspan>
+          </>
+        ) : (
+          name
+        )}
+      </text>
+      {columns.map((col, i) => {
+        const cy = HEADER_HEIGHT + i * COLUMN_HEIGHT;
+        const isPk = col.isPrimaryKey;
+        const isFk = fkCols.has(col.name);
+        return (
+          <g key={col.name}>
+            {i % 2 === 1 && (
+              <rect
+                x={0}
+                y={cy}
+                width={TABLE_WIDTH}
+                height={COLUMN_HEIGHT}
+                fill="rgba(0,0,0,0.02)"
+              />
+            )}
+            {/* PK/FK marker */}
+            {(isPk || isFk) && (
+              <circle
+                cx={12}
+                cy={cy + COLUMN_HEIGHT / 2}
+                r={4}
+                fill={isPk ? colors.pkColor : colors.fkColor}
+                stroke="#ffffff"
+                strokeWidth={1}
+              />
+            )}
+            <text
+              x={24}
+              y={cy + COLUMN_HEIGHT / 2}
+              dy="0.35em"
+              fontSize={11}
+              fill={colors.columnText}
+              fontWeight={isPk ? 600 : 400}
+            >
+              {col.name}
+            </text>
+            <text
+              x={TABLE_WIDTH - 8}
+              y={cy + COLUMN_HEIGHT / 2}
+              dy="0.35em"
+              fontSize={10}
+              fill={colors.columnText}
+              opacity={0.6}
+              textAnchor="end"
+            >
+              {truncate(col.dataType, 14)}
+            </text>
+          </g>
+        );
+      })}
+    </g>
+  );
+}
+
+function Relationships({
+  loaded,
+  diagram,
+  color,
+}: {
+  loaded: LoadedSchema;
+  diagram: DiagramState;
+  color: string;
+}) {
+  const paths: { path: string; id: string }[] = [];
+  for (const fk of loaded.foreignKeys) {
+    const srcKey = `${fk.sourceSchema}.${fk.sourceTable}`;
+    const tgtKey = `${fk.targetSchema}.${fk.targetTable}`;
+    const srcPos = diagram.positions[srcKey];
+    const tgtPos = diagram.positions[tgtKey];
+    if (!srcPos || !tgtPos) continue;
+    const srcCols = loaded.columns[srcKey] ?? [];
+    const tgtCols = loaded.columns[tgtKey] ?? [];
+    if (srcCols.length === 0 || tgtCols.length === 0) continue;
+
+    const a = columnAnchor(
+      { x: srcPos.x, y: srcPos.y, columns: srcCols },
+      fk.sourceColumn,
+      { x: tgtPos.x },
+    );
+    const b = columnAnchor(
+      { x: tgtPos.x, y: tgtPos.y, columns: tgtCols },
+      fk.targetColumn,
+      { x: srcPos.x },
+    );
+
+    const dx = Math.abs(b.x - a.x);
+    const c1x = a.x + (a.x < b.x ? dx / 2 : -dx / 2);
+    const c2x = b.x + (a.x < b.x ? -dx / 2 : dx / 2);
+    const d = `M ${a.x} ${a.y} C ${c1x} ${a.y}, ${c2x} ${b.y}, ${b.x} ${b.y}`;
+    paths.push({ path: d, id: `${fk.constraintName}-${fk.sourceColumn}` });
+  }
+
+  return (
+    <g>
+      {paths.map(({ path, id }) => (
+        <path
+          key={id}
+          d={path}
+          fill="none"
+          stroke={color}
+          strokeWidth={1.5}
+          markerEnd="url(#arrowhead-fk)"
+          opacity={0.75}
+        />
+      ))}
+    </g>
+  );
+}
+
+function AnnotationNode({
+  annotation,
+  selected,
+  onSelect,
+  onStartDrag,
+}: {
+  annotation: DiagramAnnotation;
+  selected: boolean;
+  onSelect: () => void;
+  onStartDrag: (e: React.MouseEvent) => void;
+}) {
+  const handleMouseDown = (e: React.MouseEvent) => {
+    onSelect();
+    onStartDrag(e);
+  };
+  const stroke = selected ? "#2563eb" : annotation.color ?? "#64748b";
+  if (annotation.shape === "rect") {
+    return (
+      <g onMouseDown={handleMouseDown} style={{ cursor: "move" }}>
+        <rect
+          x={annotation.x}
+          y={annotation.y}
+          width={annotation.width ?? 100}
+          height={annotation.height ?? 60}
+          fill={annotation.fill ?? "rgba(59,130,246,0.08)"}
+          stroke={stroke}
+          strokeWidth={selected ? 2 : 1.5}
+          strokeDasharray={annotation.fill ? undefined : "4 2"}
+          rx={4}
+        />
+        {annotation.text && (
+          <text
+            x={annotation.x + 8}
+            y={annotation.y + 16}
+            fontSize={annotation.fontSize ?? 12}
+            fill={annotation.color ?? "#111827"}
+          >
+            {annotation.text}
+          </text>
+        )}
+      </g>
+    );
+  }
+  if (annotation.shape === "text") {
+    return (
+      <g onMouseDown={handleMouseDown} style={{ cursor: "move" }}>
+        <text
+          x={annotation.x}
+          y={annotation.y + (annotation.fontSize ?? 14)}
+          fontSize={annotation.fontSize ?? 14}
+          fill={annotation.color ?? "#111827"}
+          fontWeight={500}
+        >
+          {annotation.text ?? "Text"}
+        </text>
+        {selected && (
+          <rect
+            x={annotation.x - 2}
+            y={annotation.y - 2}
+            width={(annotation.width ?? 160) + 4}
+            height={(annotation.height ?? 24) + 4}
+            fill="none"
+            stroke="#2563eb"
+            strokeWidth={1}
+            strokeDasharray="3 2"
+          />
+        )}
+      </g>
+    );
+  }
+  // line
+  return (
+    <g onMouseDown={handleMouseDown} style={{ cursor: "move" }}>
+      <line
+        x1={annotation.x}
+        y1={annotation.y}
+        x2={annotation.x2 ?? annotation.x + 80}
+        y2={annotation.y2 ?? annotation.y}
+        stroke={stroke}
+        strokeWidth={annotation.strokeWidth ?? 2}
+      />
+    </g>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Inspectors
+// ──────────────────────────────────────────────────────────────────────────────
+
+function TableInspector({
+  tableKey,
+  color,
+  onSetColor,
+  onClose,
+}: {
+  tableKey: string;
+  color?: string;
+  onSetColor: (c: string) => void;
+  onClose: () => void;
+}) {
+  const [, tname] = tableKey.split(".", 2);
+  return (
+    <div className="absolute right-4 top-28 z-20 w-52 rounded-md border border-border bg-background p-3 shadow-lg">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold">{tname}</div>
+        <button
+          onClick={onClose}
+          className="rounded p-0.5 text-muted-foreground hover:bg-accent"
+        >
+          <X size={11} />
+        </button>
+      </div>
+      <div className="mt-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+        Header color
+      </div>
+      <div className="mt-1 flex flex-wrap gap-1">
+        {SWATCH_COLORS.map((c) => (
+          <button
+            key={c}
+            onClick={() => onSetColor(c)}
+            style={{ backgroundColor: c }}
+            className={cn(
+              "h-5 w-5 rounded border-2",
+              color === c ? "border-foreground" : "border-transparent",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AnnotationInspector({
+  annotation,
+  onChange,
+  onDelete,
+  onClose,
+}: {
+  annotation: DiagramAnnotation;
+  onChange: (patch: Partial<DiagramAnnotation>) => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="absolute right-4 top-28 z-20 w-56 rounded-md border border-border bg-background p-3 shadow-lg">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold capitalize">{annotation.shape}</div>
+        <button
+          onClick={onClose}
+          className="rounded p-0.5 text-muted-foreground hover:bg-accent"
+        >
+          <X size={11} />
+        </button>
+      </div>
+      {(annotation.shape === "text" || annotation.shape === "rect") && (
+        <div className="mt-2">
+          <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Text
+          </div>
+          <input
+            value={annotation.text ?? ""}
+            onChange={(e) => onChange({ text: e.target.value })}
+            className="mt-1 w-full rounded border border-border bg-background px-1.5 py-0.5 text-xs"
+          />
+        </div>
+      )}
+      <div className="mt-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+        Color
+      </div>
+      <div className="mt-1 flex flex-wrap gap-1">
+        {SWATCH_COLORS.map((c) => (
+          <button
+            key={c}
+            onClick={() => onChange({ color: c })}
+            style={{ backgroundColor: c }}
+            className={cn(
+              "h-5 w-5 rounded border-2",
+              annotation.color === c ? "border-foreground" : "border-transparent",
+            )}
+          />
+        ))}
+      </div>
+      {annotation.shape === "rect" && (
+        <>
+          <div className="mt-2 text-[10px] uppercase tracking-wide text-muted-foreground">
+            Fill
+          </div>
+          <div className="mt-1 flex flex-wrap gap-1">
+            <button
+              onClick={() => onChange({ fill: undefined })}
+              className={cn(
+                "h-5 w-5 rounded border-2 bg-white",
+                !annotation.fill ? "border-foreground" : "border-transparent",
+              )}
+              title="No fill"
+            />
+            {SWATCH_COLORS.map((c) => (
+              <button
+                key={c}
+                onClick={() => onChange({ fill: c + "33" })}
+                style={{ backgroundColor: c + "33" }}
+                className={cn(
+                  "h-5 w-5 rounded border-2",
+                  annotation.fill === c + "33" ? "border-foreground" : "border-transparent",
+                )}
+              />
+            ))}
+          </div>
+        </>
+      )}
+      <button
+        onClick={onDelete}
+        className="mt-3 flex w-full items-center justify-center gap-1 rounded bg-destructive/10 py-1 text-xs text-destructive hover:bg-destructive/20"
+      >
+        <Trash2 size={11} /> Delete
+      </button>
+    </div>
+  );
+}
+
+function ColorPicker({
+  colors,
+  onChange,
+  onClose,
+}: {
+  colors: DiagramColorSettings;
+  onChange: (patch: Partial<DiagramColorSettings>) => void;
+  onClose: () => void;
+}) {
+  const fields: { key: keyof DiagramColorSettings; label: string; icon: React.ReactNode }[] = [
+    { key: "tableHeader", label: "Table header", icon: null },
+    { key: "tableBorder", label: "Table border", icon: null },
+    { key: "pkColor", label: "Primary key", icon: <Key size={10} /> },
+    { key: "fkColor", label: "Foreign key", icon: <Link2 size={10} /> },
+    { key: "relationship", label: "Relationship", icon: null },
+    { key: "columnText", label: "Column text", icon: null },
+  ];
+  return (
+    <div className="flex shrink-0 items-center gap-3 border-b border-border bg-muted/10 px-3 py-2 text-xs">
+      {fields.map((f) => (
+        <div key={f.key} className="flex items-center gap-1">
+          {f.icon}
+          <span className="text-[10px] text-muted-foreground">{f.label}</span>
+          <input
+            type="color"
+            value={colors[f.key]}
+            onChange={(e) => onChange({ [f.key]: e.target.value } as Partial<DiagramColorSettings>)}
+            className="h-5 w-6 cursor-pointer rounded border border-border"
+          />
+        </div>
+      ))}
+      <button
+        onClick={onClose}
+        className="ml-auto rounded p-1 text-muted-foreground hover:bg-accent"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Utilities
+// ──────────────────────────────────────────────────────────────────────────────
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function computeViewBox(
+  diagram: DiagramState,
+  loaded: LoadedSchema | null,
+): { x: number; y: number; width: number; height: number } {
+  let minX = 0,
+    minY = 0,
+    maxX = 1200,
+    maxY = 800;
+  const apply = (x: number, y: number, w = 0, h = 0) => {
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + w);
+    maxY = Math.max(maxY, y + h);
+  };
+  if (loaded) {
+    for (const t of loaded.tables) {
+      const key = `${t.schema}.${t.name}`;
+      const p = diagram.positions[key];
+      if (!p) continue;
+      const cols = loaded.columns[key] ?? [];
+      apply(p.x, p.y, TABLE_WIDTH, tableHeight(cols.length));
+    }
+  }
+  for (const a of diagram.annotations) {
+    if (a.shape === "line") {
+      apply(Math.min(a.x, a.x2 ?? a.x), Math.min(a.y, a.y2 ?? a.y));
+      apply(Math.max(a.x, a.x2 ?? a.x), Math.max(a.y, a.y2 ?? a.y));
+    } else {
+      apply(a.x, a.y, a.width ?? 0, a.height ?? 0);
+    }
+  }
+  // Provide some padding
+  const padding = 40;
+  return {
+    x: minX - padding,
+    y: minY - padding,
+    width: maxX - minX + padding * 2,
+    height: maxY - minY + padding * 2,
+  };
+}
+
+function fitToContent(
+  svg: SVGSVGElement | null,
+  diagram: DiagramState,
+  loaded: LoadedSchema | null,
+  setDiagram: (updater: (d: DiagramState) => DiagramState) => void,
+) {
+  if (!svg) return;
+  const container = svg.parentElement;
+  if (!container) return;
+  const box = computeViewBox(diagram, loaded);
+  const cw = container.clientWidth;
+  const ch = container.clientHeight;
+  if (box.width <= 0 || box.height <= 0) return;
+  const zoom = Math.min(cw / box.width, ch / box.height, 1);
+  const panX = (cw - box.width * zoom) / 2 - box.x * zoom;
+  const panY = (ch - box.height * zoom) / 2 - box.y * zoom;
+  setDiagram((d) => ({ ...d, zoom, panX, panY }));
+  void columnY;
+}
+
+/**
+ * Prepare a cloned <svg> for export: sets viewBox to tightly fit all content
+ * and strips the interactive pan/zoom transform so the output renders at 1:1.
+ */
+function prepareExportSvg(
+  svg: SVGSVGElement,
+  diagram: DiagramState,
+  loaded: LoadedSchema | null,
+): { clone: SVGSVGElement; width: number; height: number } {
+  const box = computeViewBox(diagram, loaded);
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+  clone.setAttribute("viewBox", `${box.x} ${box.y} ${box.width} ${box.height}`);
+  clone.setAttribute("width", String(Math.max(1, Math.round(box.width))));
+  clone.setAttribute("height", String(Math.max(1, Math.round(box.height))));
+  clone.removeAttribute("class");
+  // Strip the interactive pan/zoom transform from the top-level <g>.
+  const topG = clone.querySelector(":scope > g");
+  if (topG) topG.removeAttribute("transform");
+  return { clone, width: box.width, height: box.height };
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Export handler
+// ──────────────────────────────────────────────────────────────────────────────
+
+async function handleExport(
+  kind: "png" | "svg" | "pdf" | "drawio",
+  svg: SVGSVGElement | null,
+  diagram: DiagramState,
+  loaded: LoadedSchema | null,
+) {
+  if (!svg) return;
+  const base = `schema-${diagram.schemaName || "diagram"}`;
+  try {
+    if (kind === "drawio") {
+      if (!loaded) return;
+      const xml = buildDrawioXml(diagram, loaded.tables, loaded.columns, loaded.foreignKeys);
+      await saveTextAs(xml, `${base}.drawio`, [{ name: "drawio", extensions: ["drawio", "xml"] }]);
+      return;
+    }
+    const { clone, width, height } = prepareExportSvg(svg, diagram, loaded);
+    if (kind === "svg") {
+      const xml = serializeSvg(clone);
+      await saveTextAs(xml, `${base}.svg`, [{ name: "SVG", extensions: ["svg"] }]);
+      return;
+    }
+    if (kind === "png") {
+      const blob = await svgToPngBlob(clone, 2);
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+      await saveBytesAs(bytes, `${base}.png`, [{ name: "PNG", extensions: ["png"] }]);
+      return;
+    }
+    if (kind === "pdf") {
+      const png = await svgToPngBlob(clone, 2);
+      const pdf = await pngBlobToPdf(png, width, height);
+      const bytes = new Uint8Array(await pdf.arrayBuffer());
+      await saveBytesAs(bytes, `${base}.pdf`, [{ name: "PDF", extensions: ["pdf"] }]);
+      return;
+    }
+  } catch (err) {
+    console.error("Export failed:", err);
+  }
+}

--- a/src/lib/diagramExport.ts
+++ b/src/lib/diagramExport.ts
@@ -1,0 +1,321 @@
+import { save } from "@tauri-apps/plugin-dialog";
+import { writeFile } from "@tauri-apps/plugin-fs";
+import type { ColumnInfo, ForeignKeyInfo, TableInfo } from "../types/schema";
+import type { DiagramState } from "../types/diagram";
+import { TABLE_WIDTH, tableHeight, COLUMN_HEIGHT, HEADER_HEIGHT } from "./diagramLayout";
+
+/** Serialize the given <svg> element, inlining computed styles for portability. */
+export function serializeSvg(svg: SVGSVGElement): string {
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  // Ensure it has proper XML namespace
+  clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  clone.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
+  return '<?xml version="1.0" encoding="UTF-8"?>\n' + clone.outerHTML;
+}
+
+/**
+ * Render an SVG element to a PNG Blob at the given scale.
+ * The SVG's viewBox defines the canvas dimensions.
+ */
+export async function svgToPngBlob(svg: SVGSVGElement, scale = 2): Promise<Blob> {
+  const vb = svg.viewBox.baseVal;
+  const width = vb.width || svg.clientWidth || 1200;
+  const height = vb.height || svg.clientHeight || 800;
+
+  const xml = serializeSvg(svg);
+  const blob = new Blob([xml], { type: "image/svg+xml;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+
+  try {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error("Failed to load SVG for rasterization"));
+      img.src = url;
+    });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.floor(width * scale);
+    canvas.height = Math.floor(height * scale);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas 2D context unavailable");
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("PNG encoding failed"))), "image/png");
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/** Encode a PNG Blob into a minimal PDF document with the image centered on an A4 page. */
+export async function pngBlobToPdf(png: Blob, pxWidth: number, pxHeight: number): Promise<Blob> {
+  // PDFs with JPEG images are far simpler than with raw PNG/Flate. Convert first.
+  const jpegBlob = await pngBlobToJpegBlob(png);
+  const jpegBytes = new Uint8Array(await jpegBlob.arrayBuffer());
+
+  // A4 landscape/portrait in PDF points (1 pt = 1/72 in). 842 × 595 pt.
+  const pageW = pxWidth >= pxHeight ? 842 : 595;
+  const pageH = pxWidth >= pxHeight ? 595 : 842;
+  const margin = 24;
+  const availW = pageW - margin * 2;
+  const availH = pageH - margin * 2;
+  const scale = Math.min(availW / pxWidth, availH / pxHeight);
+  const drawW = pxWidth * scale;
+  const drawH = pxHeight * scale;
+  const tx = (pageW - drawW) / 2;
+  const ty = (pageH - drawH) / 2;
+
+  const enc = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  const offsets: number[] = [];
+  let cursor = 0;
+
+  const writeString = (s: string) => {
+    const bytes = enc.encode(s);
+    chunks.push(bytes);
+    cursor += bytes.length;
+  };
+  const writeBytes = (b: Uint8Array) => {
+    chunks.push(b);
+    cursor += b.length;
+  };
+
+  // Header
+  writeString("%PDF-1.4\n%\xff\xff\xff\xff\n");
+
+  const beginObj = () => {
+    offsets.push(cursor);
+    const num = offsets.length;
+    writeString(`${num} 0 obj\n`);
+    return num;
+  };
+  const endObj = () => writeString("\nendobj\n");
+
+  // Obj 1: Catalog
+  beginObj();
+  writeString("<< /Type /Catalog /Pages 2 0 R >>");
+  endObj();
+
+  // Obj 2: Pages
+  beginObj();
+  writeString("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+  endObj();
+
+  // Obj 3: Page
+  beginObj();
+  writeString(
+    `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 ${pageW} ${pageH}] ` +
+      `/Resources << /XObject << /Im0 4 0 R >> /ProcSet [/PDF /ImageC] >> ` +
+      `/Contents 5 0 R >>`,
+  );
+  endObj();
+
+  // Obj 4: Image XObject (JPEG via DCTDecode)
+  beginObj();
+  writeString(
+    `<< /Type /XObject /Subtype /Image /Width ${pxWidth} /Height ${pxHeight} ` +
+      `/ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /DCTDecode /Length ${jpegBytes.length} >>\nstream\n`,
+  );
+  writeBytes(jpegBytes);
+  writeString("\nendstream");
+  endObj();
+
+  // Obj 5: Page content stream
+  const stream = `q\n${drawW.toFixed(3)} 0 0 ${drawH.toFixed(3)} ${tx.toFixed(3)} ${ty.toFixed(3)} cm\n/Im0 Do\nQ\n`;
+  const streamBytes = enc.encode(stream);
+  beginObj();
+  writeString(`<< /Length ${streamBytes.length} >>\nstream\n`);
+  writeBytes(streamBytes);
+  writeString("endstream");
+  endObj();
+
+  // xref table
+  const xrefOffset = cursor;
+  let xref = `xref\n0 ${offsets.length + 1}\n0000000000 65535 f \n`;
+  for (const off of offsets) {
+    xref += off.toString().padStart(10, "0") + " 00000 n \n";
+  }
+  writeString(xref);
+  writeString(
+    `trailer\n<< /Size ${offsets.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`,
+  );
+
+  // Concatenate all chunks
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let o = 0;
+  for (const c of chunks) {
+    out.set(c, o);
+    o += c.length;
+  }
+  return new Blob([out], { type: "application/pdf" });
+}
+
+async function pngBlobToJpegBlob(png: Blob): Promise<Blob> {
+  const url = URL.createObjectURL(png);
+  try {
+    const img = new Image();
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve();
+      img.onerror = () => reject(new Error("Failed to load PNG"));
+      img.src = url;
+    });
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("Canvas context unavailable");
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0);
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (b) => (b ? resolve(b) : reject(new Error("JPEG encoding failed"))),
+        "image/jpeg",
+        0.92,
+      );
+    });
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/** Build a drawio (.drawio) XML file representing the diagram. */
+export function buildDrawioXml(
+  diagram: DiagramState,
+  tables: TableInfo[],
+  columnsByKey: Record<string, ColumnInfo[]>,
+  foreignKeys: ForeignKeyInfo[],
+): string {
+  const cells: string[] = [];
+  const idForTable = new Map<string, string>();
+  const idForColumn = new Map<string, string>();
+  let nextId = 2;
+
+  const genId = () => String(nextId++);
+
+  // Root cells
+  cells.push(`<mxCell id="0" />`);
+  cells.push(`<mxCell id="1" parent="0" />`);
+
+  for (const t of tables) {
+    const key = `${t.schema}.${t.name}`;
+    const cols = columnsByKey[key] ?? [];
+    const pos = diagram.positions[key];
+    if (!pos) continue;
+    const w = TABLE_WIDTH;
+    const h = tableHeight(cols.length);
+    const tableId = genId();
+    idForTable.set(key, tableId);
+    const headerColor = pos.color ?? "#3b82f6";
+    cells.push(
+      `<mxCell id="${tableId}" value="${escapeXml(t.name)}" ` +
+        `style="shape=table;startSize=${HEADER_HEIGHT};container=1;collapsible=0;childLayout=tableLayout;fontSize=12;strokeColor=${headerColor};fillColor=#ffffff;fontColor=#ffffff;align=left;spacingLeft=8;fillColor=${headerColor};verticalAlign=middle;" ` +
+        `vertex="1" parent="1">` +
+        `<mxGeometry x="${pos.x}" y="${pos.y}" width="${w}" height="${h}" as="geometry" />` +
+        `</mxCell>`,
+    );
+    cols.forEach((col, i) => {
+      const rowId = genId();
+      const cellId = genId();
+      idForColumn.set(`${key}.${col.name}`, cellId);
+      cells.push(
+        `<mxCell id="${rowId}" value="" ` +
+          `style="shape=tableRow;horizontal=0;startSize=0;swimlaneHead=0;swimlaneBody=0;strokeColor=inherit;top=0;left=0;bottom=0;right=0;collapsible=0;dropTarget=0;fillColor=none;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontSize=11;" ` +
+          `vertex="1" parent="${tableId}">` +
+          `<mxGeometry y="${HEADER_HEIGHT + i * COLUMN_HEIGHT}" width="${w}" height="${COLUMN_HEIGHT}" as="geometry" />` +
+          `</mxCell>`,
+      );
+      const label = `${col.isPrimaryKey ? "\uD83D\uDD11 " : ""}${col.name}: ${col.dataType}`;
+      cells.push(
+        `<mxCell id="${cellId}" value="${escapeXml(label)}" ` +
+          `style="shape=partialRectangle;html=1;whiteSpace=wrap;connectable=0;strokeColor=inherit;overflow=hidden;fillColor=none;top=0;left=0;bottom=0;right=0;pointerEvents=1;align=left;spacingLeft=6;fontSize=11;${col.isPrimaryKey ? "fontStyle=4;" : ""}" ` +
+          `vertex="1" parent="${rowId}">` +
+          `<mxGeometry width="${w}" height="${COLUMN_HEIGHT}" as="geometry" />` +
+          `</mxCell>`,
+      );
+    });
+  }
+
+  // Relationships as edges between column cells
+  for (const fk of foreignKeys) {
+    const srcId = idForColumn.get(`${fk.sourceSchema}.${fk.sourceTable}.${fk.sourceColumn}`);
+    const tgtId = idForColumn.get(`${fk.targetSchema}.${fk.targetTable}.${fk.targetColumn}`);
+    if (!srcId || !tgtId) continue;
+    cells.push(
+      `<mxCell id="${genId()}" value="" ` +
+        `style="edgeStyle=entityRelationEdgeStyle;fontSize=11;html=1;endArrow=ERmany;startArrow=ERone;rounded=0;exitX=1;exitY=0.5;entryX=0;entryY=0.5;" ` +
+        `edge="1" parent="1" source="${srcId}" target="${tgtId}">` +
+        `<mxGeometry relative="1" as="geometry" /></mxCell>`,
+    );
+  }
+
+  // Annotations
+  for (const ann of diagram.annotations) {
+    const aid = genId();
+    if (ann.shape === "rect") {
+      const style = `rounded=0;whiteSpace=wrap;html=1;fillColor=${ann.fill ?? "#ffffff"};strokeColor=${ann.color ?? "#94a3b8"};`;
+      cells.push(
+        `<mxCell id="${aid}" value="${escapeXml(ann.text ?? "")}" style="${style}" vertex="1" parent="1">` +
+          `<mxGeometry x="${ann.x}" y="${ann.y}" width="${ann.width ?? 120}" height="${ann.height ?? 80}" as="geometry" /></mxCell>`,
+      );
+    } else if (ann.shape === "text") {
+      const style = `text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=top;fontSize=${ann.fontSize ?? 12};fontColor=${ann.color ?? "#111827"};`;
+      cells.push(
+        `<mxCell id="${aid}" value="${escapeXml(ann.text ?? "")}" style="${style}" vertex="1" parent="1">` +
+          `<mxGeometry x="${ann.x}" y="${ann.y}" width="${ann.width ?? 160}" height="${ann.height ?? 24}" as="geometry" /></mxCell>`,
+      );
+    } else if (ann.shape === "line") {
+      const style = `endArrow=none;html=1;strokeColor=${ann.color ?? "#475569"};strokeWidth=${ann.strokeWidth ?? 1.5};`;
+      cells.push(
+        `<mxCell id="${aid}" style="${style}" edge="1" parent="1">` +
+          `<mxGeometry relative="1" as="geometry">` +
+          `<mxPoint x="${ann.x}" y="${ann.y}" as="sourcePoint"/>` +
+          `<mxPoint x="${ann.x2 ?? ann.x + 100}" y="${ann.y2 ?? ann.y}" as="targetPoint"/>` +
+          `</mxGeometry></mxCell>`,
+      );
+    }
+  }
+
+  return (
+    `<mxfile host="sqail" modified="${new Date().toISOString()}" agent="sqail" version="24.0.0">\n` +
+    `<diagram name="${escapeXml(diagram.schemaName)}">\n` +
+    `<mxGraphModel dx="1000" dy="600" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1200" pageHeight="800" math="0" shadow="0">\n` +
+    `<root>\n${cells.join("\n")}\n</root>\n` +
+    `</mxGraphModel>\n</diagram>\n</mxfile>\n`
+  );
+}
+
+/** Prompt the user for a save path and write the given bytes. */
+export async function saveBytesAs(
+  bytes: Uint8Array,
+  defaultName: string,
+  filters: { name: string; extensions: string[] }[],
+): Promise<boolean> {
+  const path = await save({ defaultPath: defaultName, filters });
+  if (!path) return false;
+  await writeFile(path, bytes);
+  return true;
+}
+
+export async function saveTextAs(
+  text: string,
+  defaultName: string,
+  filters: { name: string; extensions: string[] }[],
+): Promise<boolean> {
+  const bytes = new TextEncoder().encode(text);
+  return saveBytesAs(bytes, defaultName, filters);
+}

--- a/src/lib/diagramLayout.ts
+++ b/src/lib/diagramLayout.ts
@@ -1,0 +1,88 @@
+import type { ColumnInfo, ForeignKeyInfo } from "../types/schema";
+import type { DiagramTablePosition } from "../types/diagram";
+
+export const TABLE_WIDTH = 240;
+export const HEADER_HEIGHT = 32;
+export const COLUMN_HEIGHT = 22;
+
+export function tableHeight(columnCount: number): number {
+  return HEADER_HEIGHT + Math.max(1, columnCount) * COLUMN_HEIGHT + 8;
+}
+
+export function columnY(columnIndex: number): number {
+  return HEADER_HEIGHT + columnIndex * COLUMN_HEIGHT + COLUMN_HEIGHT / 2;
+}
+
+/**
+ * Arrange tables in a grid. Tables with more inbound FKs go to the center.
+ * Deterministic, fast, and good enough as a starting layout.
+ */
+export function autoLayout(
+  tables: { schema: string; name: string; columns: ColumnInfo[] }[],
+  foreignKeys: ForeignKeyInfo[],
+): Record<string, DiagramTablePosition> {
+  const PADDING_X = 80;
+  const PADDING_Y = 40;
+  const cols = Math.ceil(Math.sqrt(Math.max(1, tables.length)));
+
+  // Rank tables by total connection count (FKs + referenced by FKs)
+  const connCount = new Map<string, number>();
+  for (const fk of foreignKeys) {
+    const src = `${fk.sourceSchema}.${fk.sourceTable}`;
+    const tgt = `${fk.targetSchema}.${fk.targetTable}`;
+    connCount.set(src, (connCount.get(src) ?? 0) + 1);
+    connCount.set(tgt, (connCount.get(tgt) ?? 0) + 1);
+  }
+
+  const sorted = [...tables].sort((a, b) => {
+    const ka = `${a.schema}.${a.name}`;
+    const kb = `${b.schema}.${b.name}`;
+    return (connCount.get(kb) ?? 0) - (connCount.get(ka) ?? 0);
+  });
+
+  const positions: Record<string, DiagramTablePosition> = {};
+  let maxRowHeight = 0;
+  const rowHeights: number[] = [];
+
+  // Pre-compute row heights
+  for (let i = 0; i < sorted.length; i++) {
+    const row = Math.floor(i / cols);
+    const h = tableHeight(sorted[i].columns.length);
+    rowHeights[row] = Math.max(rowHeights[row] ?? 0, h);
+    maxRowHeight = Math.max(maxRowHeight, h);
+  }
+
+  let yOffset = 40;
+  for (let row = 0; row * cols < sorted.length; row++) {
+    for (let c = 0; c < cols; c++) {
+      const idx = row * cols + c;
+      if (idx >= sorted.length) break;
+      const t = sorted[idx];
+      const key = `${t.schema}.${t.name}`;
+      positions[key] = {
+        key,
+        x: 40 + c * (TABLE_WIDTH + PADDING_X),
+        y: yOffset,
+      };
+    }
+    yOffset += (rowHeights[row] ?? maxRowHeight) + PADDING_Y;
+  }
+
+  return positions;
+}
+
+/** Compute the anchor point on a table for a given column, at the nearer edge. */
+export function columnAnchor(
+  table: { x: number; y: number; columns: ColumnInfo[] },
+  columnName: string,
+  otherTable: { x: number } | null,
+): { x: number; y: number } {
+  const idx = Math.max(
+    0,
+    table.columns.findIndex((c) => c.name === columnName),
+  );
+  const y = table.y + columnY(idx);
+  if (!otherTable) return { x: table.x + TABLE_WIDTH, y };
+  const onRight = otherTable.x > table.x + TABLE_WIDTH / 2;
+  return { x: onRight ? table.x + TABLE_WIDTH : table.x, y };
+}

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { editor as monacoEditor } from "monaco-editor";
 import type { EditorTab } from "../types/editor";
+import { defaultDiagramState, type DiagramState } from "../types/diagram";
 
 const STORAGE_KEY = "sqail_tabs";
 
@@ -44,6 +45,8 @@ interface EditorState {
 
   addTab: () => void;
   addTabWithContent: (title: string, content: string) => void;
+  addDiagramTab: (title: string, schemaName: string, connectionId?: string) => void;
+  updateDiagram: (id: string, updater: (d: DiagramState) => DiagramState) => void;
   closeTab: (id: string) => void;
   closeOtherTabs: (id: string) => void;
   closeTabsToRight: (id: string) => void;
@@ -87,6 +90,30 @@ export const useEditorStore = create<EditorState>((set, get) => {
       const { tabs } = get();
       const tab: EditorTab = { id: generateId(), title, content };
       set({ tabs: [...tabs, tab], activeTabId: tab.id });
+      persist();
+    },
+
+    addDiagramTab: (title, schemaName, connectionId) => {
+      const { tabs } = get();
+      const tab: EditorTab = {
+        id: generateId(),
+        title,
+        content: "",
+        kind: "diagram",
+        diagram: defaultDiagramState(schemaName),
+        connectionId,
+      };
+      set({ tabs: [...tabs, tab], activeTabId: tab.id });
+      persist();
+    },
+
+    updateDiagram: (id, updater) => {
+      set((s) => ({
+        tabs: s.tabs.map((t) => {
+          if (t.id !== id || t.kind !== "diagram" || !t.diagram) return t;
+          return { ...t, diagram: updater(t.diagram) };
+        }),
+      }));
       persist();
     },
 

--- a/src/types/diagram.ts
+++ b/src/types/diagram.ts
@@ -1,0 +1,66 @@
+export interface DiagramTablePosition {
+  key: string; // `${schema}.${table}`
+  x: number;
+  y: number;
+  color?: string; // header/border color override
+}
+
+export type AnnotationShape = "rect" | "text" | "line";
+
+export interface DiagramAnnotation {
+  id: string;
+  shape: AnnotationShape;
+  x: number;
+  y: number;
+  // For rect: width/height. For line: relative endpoint (x2, y2 are absolute).
+  width?: number;
+  height?: number;
+  x2?: number;
+  y2?: number;
+  text?: string;
+  color?: string;
+  fill?: string;
+  fontSize?: number;
+  strokeWidth?: number;
+}
+
+export interface DiagramColorSettings {
+  tableHeader: string;
+  tableBorder: string;
+  tableBody: string;
+  pkColor: string;
+  fkColor: string;
+  columnText: string;
+  relationship: string;
+}
+
+export interface DiagramState {
+  schemaName: string;
+  zoom: number;
+  panX: number;
+  panY: number;
+  positions: Record<string, DiagramTablePosition>;
+  annotations: DiagramAnnotation[];
+  colors?: Partial<DiagramColorSettings>;
+  snapToGrid?: boolean;
+  // `true` if tables/FKs have been loaded at least once
+  loaded?: boolean;
+}
+
+export const DIAGRAM_GRID_SIZE = 20;
+
+export function snapValue(v: number, enabled: boolean | undefined): number {
+  return enabled ? Math.round(v / DIAGRAM_GRID_SIZE) * DIAGRAM_GRID_SIZE : v;
+}
+
+export function defaultDiagramState(schemaName: string): DiagramState {
+  return {
+    schemaName,
+    zoom: 1,
+    panX: 0,
+    panY: 0,
+    positions: {},
+    annotations: [],
+    colors: {},
+  };
+}

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,3 +1,7 @@
+import type { DiagramState } from "./diagram";
+
+export type EditorTabKind = "sql" | "diagram";
+
 export interface EditorTab {
   id: string;
   title: string;
@@ -6,4 +10,6 @@ export interface EditorTab {
   savedQueryId?: string;
   connectionId?: string;
   pinned?: boolean;
+  kind?: EditorTabKind; // default "sql"
+  diagram?: DiagramState; // present when kind === "diagram"
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -28,3 +28,14 @@ export interface RoutineInfo {
   schema: string;
   routineType: "function" | "procedure";
 }
+
+export interface ForeignKeyInfo {
+  constraintName: string;
+  sourceSchema: string;
+  sourceTable: string;
+  sourceColumn: string;
+  targetSchema: string;
+  targetTable: string;
+  targetColumn: string;
+  ordinal: number;
+}


### PR DESCRIPTION
## Summary

Adds an interactive schema diagram tab to the app and refreshes the portal
to surface the new diagramming feature alongside the local LLM + LoRA
training work shipped in v0.6.

### App — new schema diagram tab
- New \`list_foreign_keys\` Tauri command (PG / MySQL / SQLite / MSSQL) with a
  matching \`ForeignKeyInfo\` type on the frontend.
- \`EditorTab\` gains \`kind: \"sql\" | \"diagram\"\` and a persisted \`DiagramState\`
  (positions, annotations, colors, snap flag). The existing localStorage
  persistence covers it automatically.
- Open via the tab-bar \`+ ▾\` menu → **New schema diagram**. Starts empty.
- Drag tables from the object browser onto the canvas (uses the existing
  \`application/sqlai-table\` payload). Columns are fetched per table; FKs
  are fetched once per schema and merged. Dropping an already-placed table
  repositions it.
- Pan (drag empty space), zoom (mouse wheel, zooms toward cursor), drag
  tables to reposition, resize handles on selected annotations
  (rect / line / text), per-table header color + global color picker,
  Delete/Backspace removes the selection, snap-to-grid toggle (20px),
  auto-tool-reset after drawing.
- Exports: **PNG**, **SVG**, **PDF** (dependency-free — raster-to-JPEG
  embedded in a hand-written PDF), **.drawio** (ER-style cells + edges +
  annotations). Export path clones the SVG, sets a tight viewBox, and
  strips the interactive pan/zoom transform so output is rendered 1:1.
- Tables render \`schema.\` (dimmed) + \`name\` (bold) in the header.

### Portal
- Version bump to 0.6.0 / build 20260418-1 (was stale at 0.5.4).
- Hero: two new callout pills — *drag-and-drop schema diagrams* (cyan)
  and *Local LLM + LoRA fine-tuning* (yellow).
- Features: added a sixth card **Visual** for the diagram feature;
  **Smart** rewritten to lead with \"Cloud AI or a local model — your
  call.\"
- AI section: reframed as cloud-or-local, plus a new **Local LLM &
  on-device fine-tuning** subsection with three tiles — offline inline
  AI (llama.cpp sidecar), curated Qwen model catalog, database-tuned
  LoRA fine-tuning.

## Test plan
- [ ] \`pnpm check\` + \`cargo check\` pass locally (verified during dev)
- [ ] Portal \`pnpm build\` passes (verified)
- [ ] Open the app → \`+ ▾\` → **New schema diagram** → drag a table from
      the schema tree onto the canvas → table lands at the cursor with
      columns + PK marker, FK arrows appear if any
- [ ] Wheel-zoom zooms toward the cursor; drag empty space pans
- [ ] Drag a table body — moves with the mouse, snaps if Snap is on
- [ ] Select an annotation → resize via handles → Delete removes it
- [ ] Export PNG / SVG / PDF / .drawio — each opens in its native viewer
- [ ] Portal: hero shows new pills, Features has 6 cards, AI section
      shows the Local LLM subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)