### PR TITLE
feat(file-save): .sqail format + projects + per-tab AI prompt history

### DIFF
--- a/Vibecoding/deployment.md
+++ b/Vibecoding/deployment.md
@@ -1,5 +1,5 @@
 Merge the PR and
-Update the version nr (0.6.1)
+Update the version nr (0.6.2)
 Include the changelog in the release. (about page)
 Check the build for warings or error and correct them.
 commit, tag and push to github

--- a/Vibecoding/file-save-plan.md
+++ b/Vibecoding/file-save-plan.md
@@ -1,0 +1,42 @@
+# file-save implementation plan
+
+Living plan for implementing `Vibecoding/file-save.md`. Work happens on branch `feature/file-save`, landed as one commit per stage so each is reviewable.
+
+## Defaults (flag to change before building)
+
+- **Encryption passphrase:** optional. Default uses the machine-local keychain secret already used by the app; user can opt into a passphrase per-file. Cross-machine portable only with passphrase.
+- **Binary data:** base64 as spec says — only relevant once we include diagram export snapshots; skipped for now.
+- **Existing `.sql` files:** `Ctrl+S` behaviour unchanged. Save-As dialog offers `.sql` and `.sqail` filters, with `.sqail` preferred when the tab has connection/history context.
+
+## Stages
+
+### Stage 1 — `.sqail` format foundation
+- Cut branch `feature/file-save` off `main`.
+- `src/types/sqailFile.ts` — envelope types: `kind: "sql" | "diagram" | "project"`, `version`, `createdAt`, `updatedAt`, payload, optional embedded connection + prompt history.
+- Rust commands in `src-tauri/src/` for AES-GCM encrypt/decrypt of sensitive strings. Key derived from per-install secret plus optional user passphrase on save.
+- `src/lib/sqail/codec.ts` — serialize/deserialize + version upgrade handling.
+- Smoke: round-trip a fixture. No UI changes yet.
+
+### Stage 2 — Per-file AI prompt history
+- Today `aiStore.promptHistory` is global. Move into `EditorTab` (`promptHistory: AiHistoryEntry[]`).
+- `aiStore` reads/writes the active tab's history via `editorStore`.
+- `aiStore.history` (DB-backed, global) unchanged — only the palette's per-tab recency moves.
+
+### Stage 3 — Save/Load SQL tabs as `.sqail`
+- Extend `src/lib/fileOps.ts`: if user picks `.sqail`, bundle SQL content + active connection config (password encrypted) + per-tab prompt history.
+- On open `.sqail`: decode, load into tab, prompt user before registering the bundled connection (never silently add credentials).
+- `.sql` path unchanged.
+
+### Stage 4 — Save/Load diagram tabs as `.sqail`
+- Same flow for `EditorTab.kind === "diagram"`: save `DiagramState` + connection + per-tab prompt history.
+- On open, recreate the diagram tab with bundled state. Reuse Stage 1 codec/encryption.
+
+### Stage 5 — Projects
+- `src/types/project.ts`, `src/stores/projectStore.ts`.
+- Sidebar panel "Project" below connections: file tree with open/close.
+- Project saved as `.sqail` with `kind: "project"` — array of file entries (inline SQL/diagram payloads) + shared connections + shared settings.
+- Open-project restores all files as tabs.
+
+## Status tracking
+
+Progress is tracked in the session task list (TaskCreate/TaskUpdate). This document is the durable plan; the task list is the live checklist.

--- a/Vibecoding/file-save.md
+++ b/Vibecoding/file-save.md
@@ -27,3 +27,7 @@ Projects can also be saved as sqail files.
 Use human readable json structure for sqail files.
 Encode binary data as base64 strings.
 Encrypt connection strings and other sensitive data.
+
+
+As this is a big modification, it should be implemented in a separate branch.
+Plan it out carefully and implement it in stages.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +132,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -304,6 +351,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -570,6 +626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -807,6 +874,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1585,6 +1661,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,6 +2213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2892,6 +2987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl"
 version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3038,6 +3139,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3311,6 +3423,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4631,7 +4755,10 @@ dependencies = [
 name = "sqail"
 version = "0.6.1"
 dependencies = [
+ "aes-gcm",
+ "argon2",
  "async-trait",
+ "base64 0.22.1",
  "bb8",
  "bb8-tiberius",
  "chrono",
@@ -4641,6 +4768,7 @@ dependencies = [
  "hex",
  "libc",
  "log",
+ "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6030,6 +6158,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,10 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 hex = "0.4"
 sha2 = "0.10"
+aes-gcm = "0.10"
+argon2 = "0.5"
+rand = "0.8"
+base64 = "0.22"
 tiberius = { version = "0.12", default-features = false, features = ["tds73", "rustls"] }
 bb8 = "0.8"
 bb8-tiberius = "0.15"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -14,6 +14,7 @@ use crate::ai::client;
 use crate::ai::inline::sidecar::SidecarStatus;
 use crate::ai::provider::{AiHistoryEntry, AiProviderConfig, AiProviderType};
 use crate::auth::entra;
+use crate::crypto::{self, CryptoEnvelope};
 use crate::db::connections::{ConnectionConfig, Driver, MssqlAuthMethod};
 use crate::metadata::{ColumnMetadata, GeneratedMetadata, ObjectMetadata};
 use crate::pool::DbPool;
@@ -2287,3 +2288,24 @@ pub async fn training_deactivate_model(
         .await
         .map(|_| ())
 }
+
+// ============================================================================
+// .sqail file crypto
+// ============================================================================
+
+#[tauri::command]
+pub fn sqail_encrypt_secret(
+    plaintext: String,
+    passphrase: Option<String>,
+) -> Result<CryptoEnvelope, String> {
+    crypto::encrypt(&plaintext, passphrase.as_deref())
+}
+
+#[tauri::command]
+pub fn sqail_decrypt_secret(
+    envelope: CryptoEnvelope,
+    passphrase: Option<String>,
+) -> Result<String, String> {
+    crypto::decrypt(&envelope, passphrase.as_deref())
+}
+

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -1,0 +1,170 @@
+//! AES-256-GCM encryption for `.sqail` file payloads.
+//!
+//! Two modes:
+//! - **Machine key** (default): a 32-byte key stored at `<app_data>/sqail.key`.
+//!   Portable only between sessions on the same machine / user.
+//! - **Passphrase**: Argon2id-derived key. Portable across machines given the passphrase.
+//!
+//! An envelope is a small JSON object carrying the algorithm id, nonce, the
+//! salt (passphrase mode only) and the ciphertext — all base64.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use argon2::{Algorithm, Argon2, Params, Version};
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+
+const KEY_FILE: &str = "sqail.key";
+const ALG_MACHINE: &str = "AES-256-GCM/machine";
+const ALG_PASSPHRASE: &str = "AES-256-GCM/argon2id";
+
+static MACHINE_KEY_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Initialise the module with the directory that holds the machine key.
+/// Safe to call multiple times — only the first call takes effect.
+pub fn init(app_data_dir: &Path) {
+    let _ = MACHINE_KEY_PATH.set(app_data_dir.join(KEY_FILE));
+}
+
+fn machine_key_path() -> Result<&'static PathBuf, String> {
+    MACHINE_KEY_PATH
+        .get()
+        .ok_or_else(|| "crypto module not initialised".to_string())
+}
+
+fn load_or_create_machine_key() -> Result<[u8; 32], String> {
+    let path = machine_key_path()?;
+    if let Ok(bytes) = std::fs::read(path) {
+        if bytes.len() == 32 {
+            let mut key = [0u8; 32];
+            key.copy_from_slice(&bytes);
+            return Ok(key);
+        }
+    }
+    let mut key = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut key);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create key dir: {e}"))?;
+    }
+    std::fs::write(path, key).map_err(|e| format!("write key: {e}"))?;
+    Ok(key)
+}
+
+fn derive_passphrase_key(passphrase: &str, salt: &[u8]) -> Result<[u8; 32], String> {
+    // Argon2id at interactive parameters — good balance for per-file save.
+    let params = Params::new(19_456, 2, 1, Some(32))
+        .map_err(|e| format!("argon2 params: {e}"))?;
+    let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let mut out = [0u8; 32];
+    argon
+        .hash_password_into(passphrase.as_bytes(), salt, &mut out)
+        .map_err(|e| format!("argon2 derive: {e}"))?;
+    Ok(out)
+}
+
+/// On-disk envelope. `salt` is only populated in passphrase mode.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CryptoEnvelope {
+    #[serde(rename = "$enc")]
+    pub enc: bool,
+    pub alg: String,
+    pub nonce: String,
+    pub ct: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub salt: Option<String>,
+}
+
+pub fn encrypt(plaintext: &str, passphrase: Option<&str>) -> Result<CryptoEnvelope, String> {
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+    let (key_bytes, alg, salt_b64) = match passphrase {
+        Some(pw) if !pw.is_empty() => {
+            let mut salt = [0u8; 16];
+            rand::thread_rng().fill_bytes(&mut salt);
+            let k = derive_passphrase_key(pw, &salt)?;
+            (k, ALG_PASSPHRASE, Some(B64.encode(salt)))
+        }
+        _ => (load_or_create_machine_key()?, ALG_MACHINE, None),
+    };
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let ct = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_bytes())
+        .map_err(|e| format!("encrypt: {e}"))?;
+
+    Ok(CryptoEnvelope {
+        enc: true,
+        alg: alg.to_string(),
+        nonce: B64.encode(nonce_bytes),
+        ct: B64.encode(ct),
+        salt: salt_b64,
+    })
+}
+
+pub fn decrypt(env: &CryptoEnvelope, passphrase: Option<&str>) -> Result<String, String> {
+    let nonce = B64.decode(&env.nonce).map_err(|e| format!("nonce b64: {e}"))?;
+    let ct = B64.decode(&env.ct).map_err(|e| format!("ct b64: {e}"))?;
+
+    let key_bytes: [u8; 32] = match env.alg.as_str() {
+        ALG_MACHINE => load_or_create_machine_key()?,
+        ALG_PASSPHRASE => {
+            let pw = passphrase.ok_or_else(|| "passphrase required".to_string())?;
+            let salt = env
+                .salt
+                .as_ref()
+                .ok_or_else(|| "salt missing for passphrase envelope".to_string())?;
+            let salt = B64.decode(salt).map_err(|e| format!("salt b64: {e}"))?;
+            derive_passphrase_key(pw, &salt)?
+        }
+        other => return Err(format!("unknown alg: {other}")),
+    };
+
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&key_bytes));
+    let pt = cipher
+        .decrypt(Nonce::from_slice(&nonce), ct.as_ref())
+        .map_err(|_| "decrypt failed (wrong passphrase or corrupted file)".to_string())?;
+    String::from_utf8(pt).map_err(|e| format!("utf8: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_tmp_key<F: FnOnce()>(f: F) {
+        let dir = std::env::temp_dir().join(format!("sqail-crypto-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // OnceLock can only be set once per process; if a prior test set it,
+        // reuse that path — the key file is still under a temp dir.
+        let _ = MACHINE_KEY_PATH.set(dir.join(KEY_FILE));
+        f();
+    }
+
+    #[test]
+    fn machine_round_trip() {
+        with_tmp_key(|| {
+            let env = encrypt("hello, secret", None).unwrap();
+            assert_eq!(env.alg, ALG_MACHINE);
+            assert!(env.salt.is_none());
+            let pt = decrypt(&env, None).unwrap();
+            assert_eq!(pt, "hello, secret");
+        });
+    }
+
+    #[test]
+    fn passphrase_round_trip() {
+        with_tmp_key(|| {
+            let env = encrypt("top secret", Some("correct horse")).unwrap();
+            assert_eq!(env.alg, ALG_PASSPHRASE);
+            assert!(env.salt.is_some());
+            let pt = decrypt(&env, Some("correct horse")).unwrap();
+            assert_eq!(pt, "top secret");
+            assert!(decrypt(&env, Some("wrong")).is_err());
+        });
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod ai;
 mod auth;
 mod commands;
+mod crypto;
 mod db;
 mod dbservice;
 mod metadata;
@@ -51,6 +52,7 @@ pub fn run() {
                 .app_data_dir()
                 .expect("failed to resolve app data dir");
             eprintln!("App data dir: {}", app_data_dir.display());
+            crypto::init(&app_data_dir);
             let store =
                 ConnectionStore::new(app_data_dir.clone()).expect("failed to create connection store");
             let ai_provider_store = AiProviderStore::new(&app_data_dir);
@@ -146,6 +148,8 @@ pub fn run() {
             commands::training_convert_model,
             commands::training_activate_model,
             commands::training_deactivate_model,
+            commands::sqail_encrypt_secret,
+            commands::sqail_decrypt_secret,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/components/AiCommandPalette.tsx
+++ b/src/components/AiCommandPalette.tsx
@@ -49,6 +49,9 @@ const SQL_CONTEXT_FLOWS: AiFlow[] = [
   "fix_query",
 ];
 
+/** Shared empty array so the selector fallback stays referentially stable. */
+const EMPTY_PROMPT_HISTORY: string[] = [];
+
 export default function AiCommandPalette() {
   const {
     paletteOpen,
@@ -66,8 +69,6 @@ export default function AiCommandPalette() {
     selectedProviderId,
     setSelectedProviderId,
     closePalette,
-    promptHistory,
-    addToPromptHistory,
     generateSql,
     explainQuery,
     optimizeQuery,
@@ -86,6 +87,15 @@ export default function AiCommandPalette() {
   const draftRef = useRef("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const responseRef = useRef<HTMLDivElement>(null);
+
+  // Per-tab palette recency: refreshed on each open so ArrowUp/Down walks the
+  // active tab's own prompt stack. Select the raw field (stable reference)
+  // and fall back to a shared empty array so `useSyncExternalStore` never sees
+  // a new snapshot on each call.
+  const tabPromptHistory = useEditorStore(
+    (s) => s.tabs.find((t) => t.id === s.activeTabId)?.promptHistory,
+  );
+  const promptHistory = tabPromptHistory ?? EMPTY_PROMPT_HISTORY;
 
   const activeConnectionId = useConnectionStore((s) => s.activeConnectionId);
   const connections = useConnectionStore((s) => s.connections);
@@ -201,7 +211,10 @@ export default function AiCommandPalette() {
     const text = prompt.trim();
     if (!text) return;
 
-    addToPromptHistory(text);
+    {
+      const tab = useEditorStore.getState().getActiveTab();
+      if (tab) useEditorStore.getState().addPromptToTab(tab.id, text);
+    }
     setHistoryIndex(-1);
     draftRef.current = "";
 
@@ -241,17 +254,31 @@ export default function AiCommandPalette() {
   const prevStreamingRef = useRef(streaming);
   useEffect(() => {
     if (prevStreamingRef.current && !streaming && currentResponse && !error && paletteOpen) {
+      const promptForEntry = currentFlow === "generate_sql" ? prompt : getCurrentSql();
+      const timestamp = new Date().toISOString();
       const entry: AiHistoryEntry = {
         id: crypto.randomUUID(),
-        timestamp: new Date().toISOString(),
+        timestamp,
         flow: currentFlow!,
-        prompt: currentFlow === "generate_sql" ? prompt : getCurrentSql(),
+        prompt: promptForEntry,
         response: currentResponse,
         connectionId: activeConnectionId ?? undefined,
       };
       invoke("save_ai_history_entry", { entry })
         .then(() => useAiStore.getState().loadHistory())
         .catch((e) => console.error("Failed to save history:", e));
+
+      // Also record the exchange on the active tab so it can be bundled
+      // into a `.sqail` file when the user saves.
+      const tab = useEditorStore.getState().getActiveTab();
+      if (tab && currentFlow) {
+        useEditorStore.getState().appendAiHistoryEntry(tab.id, {
+          timestamp,
+          flow: currentFlow,
+          prompt: promptForEntry,
+          response: currentResponse,
+        });
+      }
     }
     prevStreamingRef.current = streaming;
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/ProjectPanel.tsx
+++ b/src/components/ProjectPanel.tsx
@@ -1,0 +1,264 @@
+import { useState } from "react";
+import {
+  FolderOpen,
+  FolderPlus,
+  FileCode2,
+  Network,
+  Save,
+  Trash2,
+  Pencil,
+  Plus,
+  X,
+} from "lucide-react";
+import { cn } from "../lib/utils";
+import { useProjectStore } from "../stores/projectStore";
+import { useEditorStore } from "../stores/editorStore";
+
+export default function ProjectPanel() {
+  const project = useProjectStore((s) => s.project);
+  const newProject = useProjectStore((s) => s.newProject);
+  const closeProject = useProjectStore((s) => s.closeProject);
+  const openProjectDialog = useProjectStore((s) => s.openProjectDialog);
+  const saveProject = useProjectStore((s) => s.saveProject);
+  const saveProjectAs = useProjectStore((s) => s.saveProjectAs);
+  const addActiveTabToProject = useProjectStore((s) => s.addActiveTabToProject);
+  const openFile = useProjectStore((s) => s.openFile);
+  const removeFile = useProjectStore((s) => s.removeFile);
+  const renameFile = useProjectStore((s) => s.renameFile);
+
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
+
+  const tabs = useEditorStore((s) => s.tabs);
+  const activeTabId = useEditorStore((s) => s.activeTabId);
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+  const activeAlreadyLinked = !!activeTab?.projectFileId;
+
+  if (!project) {
+    return (
+      <div className="flex h-full flex-col items-stretch justify-start gap-2 p-3">
+        <p className="text-xs text-muted-foreground">
+          No project is open. Projects bundle related SQL scripts and diagrams (plus their
+          connection + AI history) into a single <code className="rounded bg-muted px-1">.sqail</code>{" "}
+          file.
+        </p>
+        <button
+          onClick={() => newProject()}
+          className="flex items-center gap-2 rounded-md border border-border px-2 py-1.5 text-xs hover:bg-accent"
+        >
+          <FolderPlus size={12} />
+          New project
+        </button>
+        <button
+          onClick={() => openProjectDialog().catch(console.error)}
+          className="flex items-center gap-2 rounded-md border border-border px-2 py-1.5 text-xs hover:bg-accent"
+        >
+          <FolderOpen size={12} />
+          Open project…
+        </button>
+      </div>
+    );
+  }
+
+  const handleRename = (id: string, title: string) => {
+    setRenamingId(id);
+    setRenameDraft(title);
+  };
+
+  const commitRename = () => {
+    if (renamingId && renameDraft.trim()) {
+      renameFile(renamingId, renameDraft.trim());
+    }
+    setRenamingId(null);
+    setRenameDraft("");
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header with project name and actions */}
+      <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1.5">
+        <ProjectNameEditor
+          name={project.name}
+          onRename={(name) => {
+            // Reuse newProject's persist path by mutating through the store.
+            useProjectStore.setState((s) =>
+              s.project ? { project: { ...s.project, name } } : s,
+            );
+            // Persist via saveProject is not appropriate here (renames should be
+            // reflected in-memory immediately; next save picks them up).
+            const proj = useProjectStore.getState().project;
+            if (proj) localStorage.setItem("sqail_active_project", JSON.stringify(proj));
+          }}
+        />
+        <button
+          onClick={() => saveProject().catch(console.error)}
+          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          title="Save project"
+        >
+          <Save size={12} />
+        </button>
+        <button
+          onClick={() => saveProjectAs().catch(console.error)}
+          className="rounded px-1 text-[9px] font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          title="Save project as…"
+        >
+          As…
+        </button>
+        <button
+          onClick={() => closeProject()}
+          className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+          title="Close project (unsaved changes are kept in open tabs)"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      {/* Add-tab button */}
+      <div className="shrink-0 border-b border-border px-2 py-1.5">
+        <button
+          onClick={() => addActiveTabToProject()}
+          disabled={!activeTab || activeAlreadyLinked}
+          className={cn(
+            "flex w-full items-center gap-2 rounded-md border border-border px-2 py-1 text-[11px] transition-colors",
+            activeTab && !activeAlreadyLinked
+              ? "hover:bg-accent"
+              : "cursor-not-allowed opacity-50",
+          )}
+          title={
+            !activeTab
+              ? "No active tab"
+              : activeAlreadyLinked
+                ? "Active tab is already part of a project file"
+                : "Add the active tab to this project"
+          }
+        >
+          <Plus size={11} />
+          Add current tab
+        </button>
+      </div>
+
+      {/* File list */}
+      <div className="flex-1 overflow-y-auto">
+        {project.files.length === 0 ? (
+          <p className="p-3 text-[11px] text-muted-foreground">
+            This project has no files yet. Open a SQL tab or diagram and click{" "}
+            <em>Add current tab</em> above.
+          </p>
+        ) : (
+          <ul className="py-1">
+            {project.files.map((f) => {
+              const linked = tabs.find((t) => t.projectFileId === f.id);
+              const Icon = f.kind === "diagram" ? Network : FileCode2;
+              return (
+                <li
+                  key={f.id}
+                  className={cn(
+                    "group flex items-center gap-1.5 px-2 py-1 text-[11px] hover:bg-accent/50",
+                    linked && linked.id === activeTabId && "bg-accent",
+                  )}
+                >
+                  <Icon size={11} className="shrink-0 text-muted-foreground" />
+                  {renamingId === f.id ? (
+                    <input
+                      autoFocus
+                      value={renameDraft}
+                      onChange={(e) => setRenameDraft(e.target.value)}
+                      onBlur={commitRename}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename();
+                        if (e.key === "Escape") {
+                          setRenamingId(null);
+                          setRenameDraft("");
+                        }
+                      }}
+                      className="flex-1 rounded border border-border bg-background px-1 py-0.5 text-[11px] outline-none"
+                    />
+                  ) : (
+                    <button
+                      onClick={() => openFile(f.id)}
+                      onDoubleClick={() => handleRename(f.id, f.title)}
+                      className="flex-1 truncate text-left"
+                      title={f.title}
+                    >
+                      {f.title}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => handleRename(f.id, f.title)}
+                    className="opacity-0 transition-opacity group-hover:opacity-100"
+                    title="Rename"
+                  >
+                    <Pencil size={10} className="text-muted-foreground hover:text-foreground" />
+                  </button>
+                  <button
+                    onClick={() => {
+                      if (window.confirm(`Remove "${f.title}" from this project?`)) {
+                        removeFile(f.id);
+                      }
+                    }}
+                    className="opacity-0 transition-opacity group-hover:opacity-100"
+                    title="Remove from project"
+                  >
+                    <Trash2
+                      size={10}
+                      className="text-muted-foreground hover:text-destructive"
+                    />
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProjectNameEditor({
+  name,
+  onRename,
+}: {
+  name: string;
+  onRename: (name: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(name);
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => {
+          if (draft.trim()) onRename(draft.trim());
+          setEditing(false);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            if (draft.trim()) onRename(draft.trim());
+            setEditing(false);
+          }
+          if (e.key === "Escape") {
+            setDraft(name);
+            setEditing(false);
+          }
+        }}
+        className="flex-1 rounded border border-border bg-background px-1.5 py-0.5 text-xs outline-none"
+      />
+    );
+  }
+
+  return (
+    <button
+      onClick={() => {
+        setDraft(name);
+        setEditing(true);
+      }}
+      className="flex-1 truncate text-left text-xs font-medium hover:text-primary"
+      title="Rename project"
+    >
+      {name}
+    </button>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   TableProperties,
   Clock,
   Bookmark,
+  FolderGit2,
 } from "lucide-react";
 import { cn } from "../lib/utils";
 import { useConnectionStore } from "../stores/connectionStore";
@@ -24,7 +25,8 @@ import ConnectionForm from "./ConnectionForm";
 import SchemaTree from "./SchemaTree";
 import QueryHistoryPanel from "./QueryHistoryPanel";
 import SavedQueriesPanel from "./SavedQueriesPanel";
-type BottomTab = "schema" | "history" | "saved";
+import ProjectPanel from "./ProjectPanel";
+type BottomTab = "schema" | "history" | "saved" | "project";
 
 interface SidebarProps {
   collapsed: boolean;
@@ -393,6 +395,7 @@ export default function Sidebar({ collapsed, onToggle, externalFormOpen, onExter
                 { id: "schema" as const, icon: TableProperties, label: "Schema" },
                 { id: "history" as const, icon: Clock, label: "History" },
                 { id: "saved" as const, icon: Bookmark, label: "Saved" },
+                { id: "project" as const, icon: FolderGit2, label: "Project" },
               ]).map(({ id, icon: Icon, label }) => (
                 <button
                   key={id}
@@ -415,6 +418,7 @@ export default function Sidebar({ collapsed, onToggle, externalFormOpen, onExter
                 <QueryHistoryPanel onSaveQuery={handleSaveFromHistory} />
               )}
               {bottomTab === "saved" && <SavedQueriesPanel />}
+              {bottomTab === "project" && <ProjectPanel />}
             </div>
           </div>
         )}

--- a/src/lib/fileOps.ts
+++ b/src/lib/fileOps.ts
@@ -1,73 +1,276 @@
 import { save, open } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { invoke } from "@tauri-apps/api/core";
 import { useEditorStore } from "../stores/editorStore";
+import { useConnectionStore } from "../stores/connectionStore";
+import { useProjectStore } from "../stores/projectStore";
+import type { ConnectionConfig } from "../types/connection";
+import type { EditorTab } from "../types/editor";
+import type {
+  SqailDiagramPayload,
+  SqailPlainPayload,
+  SqailPromptEntry,
+  SqailSqlPayload,
+} from "../types/sqailFile";
+import {
+  decryptPayloadSecrets,
+  encodeSqailFile,
+  parseSqailFile,
+  serializeSqailFile,
+} from "./sqail/codec";
 
-const SQL_FILTER = {
-  name: "SQL Files",
-  extensions: ["sql"],
-};
+const SQL_FILTER = { name: "SQL Files", extensions: ["sql"] };
+const SQAIL_FILTER = { name: "sqail Bundles", extensions: ["sqail"] };
 
-/** Save the active tab's content. If it already has a filePath, overwrite; otherwise show Save As dialog. */
+function isSqailPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".sqail");
+}
+
+function fileNameFromPath(path: string): string {
+  return path.split(/[/\\]/).pop() ?? path;
+}
+
+function lookupConnection(id: string | undefined): ConnectionConfig | undefined {
+  if (!id) return undefined;
+  return useConnectionStore.getState().connections.find((c) => c.id === id);
+}
+
+function buildPayloadFromTab(tab: EditorTab): SqailPlainPayload {
+  const connection = lookupConnection(tab.connectionId);
+  const promptHistory: SqailPromptEntry[] = tab.aiHistory ?? [];
+  if (tab.kind === "diagram" && tab.diagram) {
+    const data: SqailDiagramPayload<ConnectionConfig> = {
+      title: tab.title,
+      diagram: tab.diagram,
+      connection,
+      promptHistory,
+    };
+    return { kind: "diagram", data };
+  }
+  const data: SqailSqlPayload<ConnectionConfig> = {
+    title: tab.title,
+    sql: tab.content,
+    connection,
+    promptHistory,
+  };
+  return { kind: "sql", data };
+}
+
+async function writeSqail(tab: EditorTab, path: string): Promise<void> {
+  const payload = buildPayloadFromTab(tab);
+  const file = await encodeSqailFile(payload);
+  await writeTextFile(path, serializeSqailFile(file));
+}
+
+async function writePlainSql(tab: EditorTab, path: string): Promise<void> {
+  await writeTextFile(path, tab.content);
+}
+
+// ---------------------------------------------------------------------------
+// Save
+
 export async function saveQuery(): Promise<void> {
-  const store = useEditorStore.getState();
-  const tab = store.getActiveTab();
-  if (!tab || !tab.content) return;
+  const tab = useEditorStore.getState().getActiveTab();
+  if (!tab) return;
 
   if (tab.filePath) {
-    await writeTextFile(tab.filePath, tab.content);
-  } else {
-    await saveQueryAs();
+    if (isSqailPath(tab.filePath)) {
+      await writeSqail(tab, tab.filePath);
+    } else {
+      if (!tab.content) return;
+      await writePlainSql(tab, tab.filePath);
+    }
+    return;
   }
+  await saveQueryAs();
 }
 
-/** Always show the Save As dialog, then write. */
 export async function saveQueryAs(): Promise<void> {
-  const store = useEditorStore.getState();
-  const tab = store.getActiveTab();
-  if (!tab || !tab.content) return;
+  const tab = useEditorStore.getState().getActiveTab();
+  if (!tab) return;
 
-  const filePath = await save({
-    filters: [SQL_FILTER],
-    defaultPath: `${tab.title}.sql`,
+  const isDiagram = tab.kind === "diagram";
+  // Diagrams have no plain-text representation — always .sqail.
+  // SQL tabs: default to .sqail when there's context worth bundling
+  // (connection or AI history); otherwise default to plain .sql.
+  const hasContext =
+    !!tab.connectionId || (tab.aiHistory && tab.aiHistory.length > 0);
+  const filters = isDiagram
+    ? [SQAIL_FILTER]
+    : hasContext
+      ? [SQAIL_FILTER, SQL_FILTER]
+      : [SQL_FILTER, SQAIL_FILTER];
+
+  const defaultExt = filters[0].extensions[0];
+  const path = await save({
+    filters,
+    defaultPath: `${tab.title}.${defaultExt}`,
   });
+  if (!path) return;
 
-  if (!filePath) return; // user cancelled
+  if (isSqailPath(path)) {
+    await writeSqail(tab, path);
+  } else {
+    if (isDiagram) {
+      // Dialog returned a non-sqail path despite the filter — shouldn't happen,
+      // but bail cleanly rather than silently losing the diagram.
+      throw new Error("Diagrams can only be saved as .sqail files");
+    }
+    if (!tab.content) return;
+    await writePlainSql(tab, path);
+  }
 
-  await writeTextFile(filePath, tab.content);
-  store.setFilePath(tab.id, filePath);
-
-  // Update tab title to the filename
-  const fileName = filePath.split(/[/\\]/).pop() ?? filePath;
-  store.renameTab(tab.id, fileName);
+  const store = useEditorStore.getState();
+  store.setFilePath(tab.id, path);
+  store.renameTab(tab.id, fileNameFromPath(path));
 }
 
-/** Show Open dialog, read the file, load into the current tab (if empty) or a new tab. */
+// ---------------------------------------------------------------------------
+// Open
+
 export async function openQuery(): Promise<void> {
-  const filePath = await open({
-    filters: [SQL_FILTER],
+  const path = await open({
+    filters: [
+      { name: "SQL or sqail", extensions: ["sql", "sqail"] },
+      SQL_FILTER,
+      SQAIL_FILTER,
+    ],
     multiple: false,
   });
+  if (!path) return;
+  const pathStr = path as string;
+  const content = await readTextFile(pathStr);
 
-  if (!filePath) return; // user cancelled
-
-  const content = await readTextFile(filePath as string);
-  const store = useEditorStore.getState();
-  const tab = store.getActiveTab();
-
-  const fileName = (filePath as string).split(/[/\\]/).pop() ?? (filePath as string);
-
-  // If current tab is empty, load into it; otherwise create a new tab
-  if (tab && !tab.content.trim()) {
-    store.setContent(tab.id, content);
-    store.setFilePath(tab.id, filePath as string);
-    store.renameTab(tab.id, fileName);
+  if (isSqailPath(pathStr)) {
+    await openSqailFile(content, pathStr);
   } else {
-    store.addTab();
-    const newTab = store.getActiveTab();
-    if (newTab) {
-      store.setContent(newTab.id, content);
-      store.setFilePath(newTab.id, filePath as string);
-      store.renameTab(newTab.id, fileName);
-    }
+    openPlainSql(content, pathStr);
   }
+}
+
+function openPlainSql(content: string, path: string): void {
+  const store = useEditorStore.getState();
+  const fileName = fileNameFromPath(path);
+  const active = store.getActiveTab();
+  if (active && !active.content.trim()) {
+    store.setContent(active.id, content);
+    store.setFilePath(active.id, path);
+    store.renameTab(active.id, fileName);
+    return;
+  }
+  store.addRestoredTab({ title: fileName, content, filePath: path });
+}
+
+async function openSqailFile(raw: string, path: string): Promise<void> {
+  const file = parseSqailFile(raw);
+
+  let passphrase: string | undefined;
+  if (file.passphraseProtected) {
+    const entered = window.prompt(
+      `"${fileNameFromPath(path)}" is passphrase-protected. Enter the passphrase to open it:`,
+    );
+    if (entered == null) return; // user cancelled
+    passphrase = entered;
+  }
+
+  let plain: SqailPlainPayload;
+  try {
+    plain = await decryptPayloadSecrets(file.payload, passphrase);
+  } catch (e) {
+    window.alert(`Failed to open .sqail file: ${String(e)}`);
+    return;
+  }
+
+  switch (plain.kind) {
+    case "sql":
+      await restoreSqlTab(plain.data, path);
+      break;
+    case "diagram":
+      await restoreDiagramTab(plain.data, path);
+      break;
+    case "project":
+      await useProjectStore.getState().adoptProjectPayload(plain.data, path);
+      break;
+  }
+}
+
+async function restoreSqlTab(
+  data: SqailSqlPayload<ConnectionConfig>,
+  path: string,
+): Promise<void> {
+  const connectionId = await maybeRegisterConnection(data.connection);
+  const fileName = fileNameFromPath(path);
+  useEditorStore.getState().addRestoredTab({
+    title: fileName,
+    content: data.sql ?? "",
+    filePath: path,
+    connectionId,
+    promptHistory: lastPrompts(data.promptHistory),
+    aiHistory: data.promptHistory ?? [],
+  });
+}
+
+async function restoreDiagramTab(
+  data: SqailDiagramPayload<ConnectionConfig>,
+  path: string,
+): Promise<void> {
+  const connectionId = await maybeRegisterConnection(data.connection);
+  const fileName = fileNameFromPath(path);
+  useEditorStore.getState().addRestoredTab({
+    title: fileName,
+    content: "",
+    kind: "diagram",
+    diagram: data.diagram,
+    filePath: path,
+    connectionId,
+    promptHistory: lastPrompts(data.promptHistory),
+    aiHistory: data.promptHistory ?? [],
+  });
+}
+
+/** Extract the last ~10 prompt strings so the palette's ArrowUp/Down list is populated. */
+function lastPrompts(entries: SqailPromptEntry[] | undefined): string[] {
+  if (!entries || entries.length === 0) return [];
+  const prompts = entries
+    .map((e) => e.prompt)
+    .filter((p): p is string => typeof p === "string" && p.length > 0);
+  return prompts.slice(-10);
+}
+
+/**
+ * If the file bundled a connection, ask the user whether to add it to the
+ * connection list. Credentials are never added silently — the user must opt in.
+ * Returns the connection id to associate with the restored tab (or undefined).
+ */
+async function maybeRegisterConnection(
+  bundled: ConnectionConfig | undefined,
+): Promise<string | undefined> {
+  if (!bundled) return undefined;
+
+  const { connections } = useConnectionStore.getState();
+  // Match by a stable tuple of (driver, host, port, database, user, filePath).
+  const existing = connections.find(
+    (c) =>
+      c.driver === bundled.driver &&
+      c.host === bundled.host &&
+      c.port === bundled.port &&
+      c.database === bundled.database &&
+      c.user === bundled.user &&
+      c.filePath === bundled.filePath,
+  );
+  if (existing) return existing.id;
+
+  const label =
+    bundled.name ||
+    `${bundled.driver}://${bundled.user ? bundled.user + "@" : ""}${bundled.host}${bundled.port ? ":" + bundled.port : ""}${bundled.database ? "/" + bundled.database : ""}`;
+  const ok = window.confirm(
+    `This file bundles a database connection:\n\n  ${label}\n\nAdd it to your saved connections? Credentials will be stored locally.`,
+  );
+  if (!ok) return undefined;
+
+  // Strip id so the backend assigns a new one.
+  const toCreate: ConnectionConfig = { ...bundled, id: "" };
+  const created = await invoke<ConnectionConfig>("create_connection", { config: toCreate });
+  await useConnectionStore.getState().loadConnections();
+  return created.id;
 }

--- a/src/lib/sqail/codec.ts
+++ b/src/lib/sqail/codec.ts
@@ -1,0 +1,233 @@
+import { invoke } from "@tauri-apps/api/core";
+import type { ConnectionConfig } from "../../types/connection";
+import {
+  SQAIL_FILE_VERSION,
+  type EncryptedField,
+  type SqailConnection,
+  type SqailDiagramPayload,
+  type SqailFile,
+  type SqailPayload,
+  type SqailPlainPayload,
+  type SqailProjectFile,
+  type SqailSqlPayload,
+} from "../../types/sqailFile";
+
+/** Build a `.sqail` file envelope around a payload. */
+export async function encodeSqailFile(
+  payload: SqailPlainPayload,
+  passphrase?: string,
+): Promise<SqailFile> {
+  // Scan the payload for embedded connections and encrypt their sensitive fields.
+  // The encoded form is immutable from the caller's point of view — we clone.
+  const encoded = await encryptPayloadSecrets(payload, passphrase);
+  const now = new Date().toISOString();
+  return {
+    magic: "sqail",
+    version: SQAIL_FILE_VERSION,
+    createdAt: now,
+    updatedAt: now,
+    encrypted: encoded.hadSecrets,
+    passphraseProtected: encoded.hadSecrets && !!passphrase,
+    payload: encoded.payload,
+  };
+}
+
+/** Serialise a `.sqail` file envelope to pretty JSON. */
+export function serializeSqailFile(file: SqailFile): string {
+  return JSON.stringify(file, null, 2);
+}
+
+/** Parse a `.sqail` file envelope from JSON. Throws on magic/version mismatch. */
+export function parseSqailFile(raw: string): SqailFile {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Not a valid JSON file");
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (parsed as { magic?: unknown }).magic !== "sqail"
+  ) {
+    throw new Error("Not a sqail file (missing magic)");
+  }
+  const file = parsed as SqailFile;
+  if (file.version > SQAIL_FILE_VERSION) {
+    throw new Error(
+      `Unsupported .sqail version ${file.version} — this build supports up to v${SQAIL_FILE_VERSION}`,
+    );
+  }
+  return file;
+}
+
+/** Decrypt sensitive fields inside a decoded `.sqail`. Returns the plain payload. */
+export async function decryptPayloadSecrets(
+  payload: SqailPayload,
+  passphrase?: string,
+): Promise<SqailPlainPayload> {
+  switch (payload.kind) {
+    case "sql": {
+      const p = payload.data;
+      return {
+        kind: "sql",
+        data: {
+          title: p.title,
+          sql: p.sql,
+          promptHistory: p.promptHistory,
+          connection: p.connection ? await decryptConnection(p.connection, passphrase) : undefined,
+        },
+      };
+    }
+    case "diagram": {
+      const p = payload.data;
+      return {
+        kind: "diagram",
+        data: {
+          title: p.title,
+          diagram: p.diagram,
+          promptHistory: p.promptHistory,
+          connection: p.connection ? await decryptConnection(p.connection, passphrase) : undefined,
+        },
+      };
+    }
+    case "project": {
+      const src = payload.data;
+      const connections = src.connections
+        ? await Promise.all(src.connections.map((c) => decryptConnection(c, passphrase)))
+        : undefined;
+      const files: SqailProjectFile<ConnectionConfig>[] = await Promise.all(
+        src.files.map(async (f): Promise<SqailProjectFile<ConnectionConfig>> => {
+          if (f.kind === "sql") {
+            const fp = f.payload as SqailSqlPayload;
+            const payload: SqailSqlPayload<ConnectionConfig> = {
+              title: fp.title,
+              sql: fp.sql,
+              promptHistory: fp.promptHistory,
+              connection: fp.connection
+                ? await decryptConnection(fp.connection, passphrase)
+                : undefined,
+            };
+            return { kind: "sql", payload };
+          }
+          const fp = f.payload as SqailDiagramPayload;
+          const payload: SqailDiagramPayload<ConnectionConfig> = {
+            title: fp.title,
+            diagram: fp.diagram,
+            promptHistory: fp.promptHistory,
+            connection: fp.connection
+              ? await decryptConnection(fp.connection, passphrase)
+              : undefined,
+          };
+          return { kind: "diagram", payload };
+        }),
+      );
+      return { kind: "project", data: { name: src.name, files, connections } };
+    }
+  }
+}
+
+/** Strip encryption envelopes from a `SqailConnection` back into a usable `ConnectionConfig`. */
+export async function decryptConnection(
+  encrypted: SqailConnection,
+  passphrase?: string,
+): Promise<ConnectionConfig> {
+  const password = await decryptMaybe(encrypted.password, passphrase);
+  const dbserviceApiKey = await decryptMaybe(encrypted.dbserviceApiKey, passphrase);
+  return { ...encrypted, password, dbserviceApiKey };
+}
+
+// ---------------------------------------------------------------------------
+
+async function encryptPayloadSecrets(
+  payload: SqailPlainPayload,
+  passphrase?: string,
+): Promise<{ payload: SqailPayload; hadSecrets: boolean }> {
+  let hadSecrets = false;
+  const encryptConn = async (c: ConnectionConfig): Promise<SqailConnection> => {
+    const password = c.password ? await encryptString(c.password, passphrase) : "";
+    const dbserviceApiKey = c.dbserviceApiKey
+      ? await encryptString(c.dbserviceApiKey, passphrase)
+      : "";
+    if (password !== "" || dbserviceApiKey !== "") hadSecrets = true;
+    return { ...c, password, dbserviceApiKey };
+  };
+
+  switch (payload.kind) {
+    case "sql": {
+      const data = { ...payload.data };
+      const out: SqailPayload = {
+        kind: "sql",
+        data: {
+          ...data,
+          connection: data.connection ? await encryptConn(data.connection) : undefined,
+        },
+      };
+      return { payload: out, hadSecrets };
+    }
+    case "diagram": {
+      const data = { ...payload.data };
+      const out: SqailPayload = {
+        kind: "diagram",
+        data: {
+          ...data,
+          connection: data.connection ? await encryptConn(data.connection) : undefined,
+        },
+      };
+      return { payload: out, hadSecrets };
+    }
+    case "project": {
+      const src = payload.data;
+      const connections = src.connections
+        ? await Promise.all(src.connections.map((c) => encryptConn(c)))
+        : undefined;
+      const files: SqailProjectFile[] = await Promise.all(
+        src.files.map(async (f): Promise<SqailProjectFile> => {
+          if (f.kind === "sql") {
+            const p = f.payload as SqailSqlPayload<ConnectionConfig>;
+            const payload: SqailSqlPayload = {
+              title: p.title,
+              sql: p.sql,
+              promptHistory: p.promptHistory,
+              connection: p.connection ? await encryptConn(p.connection) : undefined,
+            };
+            return { kind: "sql", payload };
+          }
+          const p = f.payload as SqailDiagramPayload<ConnectionConfig>;
+          const payload: SqailDiagramPayload = {
+            title: p.title,
+            diagram: p.diagram,
+            promptHistory: p.promptHistory,
+            connection: p.connection ? await encryptConn(p.connection) : undefined,
+          };
+          return { kind: "diagram", payload };
+        }),
+      );
+      return {
+        payload: { kind: "project", data: { name: src.name, files, connections } },
+        hadSecrets,
+      };
+    }
+  }
+}
+
+async function encryptString(
+  plaintext: string,
+  passphrase: string | undefined,
+): Promise<EncryptedField> {
+  return invoke<EncryptedField>("sqail_encrypt_secret", {
+    plaintext,
+    passphrase: passphrase ?? null,
+  });
+}
+
+async function decryptMaybe(
+  field: EncryptedField | "",
+  passphrase: string | undefined,
+): Promise<string> {
+  if (field === "") return "";
+  return invoke<string>("sqail_decrypt_secret", {
+    envelope: field,
+    passphrase: passphrase ?? null,
+  });
+}

--- a/src/stores/aiStore.ts
+++ b/src/stores/aiStore.ts
@@ -117,10 +117,6 @@ interface AiState {
 
   loadHistory: () => Promise<void>;
   clearHistory: () => Promise<void>;
-
-  /** Last 10 prompts entered in the palette (newest last). */
-  promptHistory: string[];
-  addToPromptHistory: (prompt: string) => void;
 }
 
 export const useAiStore = create<AiState>((set, get) => ({
@@ -145,7 +141,6 @@ export const useAiStore = create<AiState>((set, get) => ({
   paletteError: "",
   diffPreview: null,
   selectedProviderId: null,
-  promptHistory: [],
 
   setSelectedProviderId: (id) => set({ selectedProviderId: id }),
 
@@ -233,14 +228,6 @@ export const useAiStore = create<AiState>((set, get) => ({
     }),
   closePalette: () =>
     set({ paletteOpen: false, paletteFlow: null, paletteSql: "", paletteError: "" }),
-
-  addToPromptHistory: (prompt) => {
-    const { promptHistory } = get();
-    // Avoid consecutive duplicates
-    if (promptHistory[promptHistory.length - 1] === prompt) return;
-    const updated = [...promptHistory, prompt].slice(-10);
-    set({ promptHistory: updated });
-  },
 
   generateSql: async (prompt, schemaContext, driver) => {
     const providerId = resolveDispatchProviderId(get().selectedProviderId);

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,8 +1,11 @@
 import { create } from "zustand";
 import type { editor as monacoEditor } from "monaco-editor";
 import type { EditorTab } from "../types/editor";
+import type { SqailPromptEntry } from "../types/sqailFile";
 import { defaultDiagramState, type DiagramState } from "../types/diagram";
 import { consumeHandoffTab, isDetachedWindow, tabStorageKey } from "../lib/detach";
+
+const PROMPT_RECENCY_LIMIT = 10;
 
 const STORAGE_KEY = tabStorageKey();
 const DETACHED = isDetachedWindow();
@@ -56,6 +59,8 @@ interface EditorState {
   addTab: () => void;
   addTabWithContent: (title: string, content: string) => void;
   addDiagramTab: (title: string, schemaName: string, connectionId?: string) => void;
+  /** Add a fully-specified tab (used when restoring from a `.sqail` file). */
+  addRestoredTab: (descriptor: Omit<EditorTab, "id">) => EditorTab;
   updateDiagram: (id: string, updater: (d: DiagramState) => DiagramState) => void;
   reorderTabs: (fromId: string, toId: string, side: "before" | "after") => void;
   closeTab: (id: string) => void;
@@ -69,6 +74,10 @@ interface EditorState {
   setConnectionId: (id: string, connectionId: string | undefined) => void;
   setSavedQueryId: (id: string, savedQueryId: string) => void;
   togglePin: (id: string) => void;
+  /** Append to the tab's palette recency (dedupes consecutive; caps at 10). */
+  addPromptToTab: (id: string, prompt: string) => void;
+  /** Append a rich AI exchange to the tab's per-file history. */
+  appendAiHistoryEntry: (id: string, entry: SqailPromptEntry) => void;
   findTabBySavedQueryId: (savedQueryId: string) => EditorTab | undefined;
   getActiveTab: () => EditorTab | undefined;
   clearActiveTab: () => void;
@@ -119,6 +128,14 @@ export const useEditorStore = create<EditorState>((set, get) => {
       };
       set({ tabs: [...tabs, tab], activeTabId: tab.id });
       persist();
+    },
+
+    addRestoredTab: (descriptor) => {
+      const { tabs } = get();
+      const tab: EditorTab = { id: generateId(), ...descriptor };
+      set({ tabs: [...tabs, tab], activeTabId: tab.id });
+      persist();
+      return tab;
     },
 
     updateDiagram: (id, updater) => {
@@ -234,6 +251,30 @@ export const useEditorStore = create<EditorState>((set, get) => {
     togglePin: (id) => {
       set((s) => ({
         tabs: s.tabs.map((t) => (t.id === id ? { ...t, pinned: !t.pinned } : t)),
+      }));
+      persist();
+    },
+
+    addPromptToTab: (id, prompt) => {
+      set((s) => ({
+        tabs: s.tabs.map((t) => {
+          if (t.id !== id) return t;
+          const existing = t.promptHistory ?? [];
+          if (existing[existing.length - 1] === prompt) return t;
+          const updated = [...existing, prompt].slice(-PROMPT_RECENCY_LIMIT);
+          return { ...t, promptHistory: updated };
+        }),
+      }));
+      persist();
+    },
+
+    appendAiHistoryEntry: (id, entry) => {
+      set((s) => ({
+        tabs: s.tabs.map((t) => {
+          if (t.id !== id) return t;
+          const existing = t.aiHistory ?? [];
+          return { ...t, aiHistory: [...existing, entry] };
+        }),
       }));
       persist();
     },

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -1,0 +1,399 @@
+import { create } from "zustand";
+import { save, open } from "@tauri-apps/plugin-dialog";
+import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
+import { invoke } from "@tauri-apps/api/core";
+import type { ConnectionConfig } from "../types/connection";
+import type { EditorTab } from "../types/editor";
+import type { Project, ProjectFile } from "../types/project";
+import type {
+  SqailDiagramPayload,
+  SqailPlainPayload,
+  SqailProjectFile,
+  SqailProjectPayload,
+  SqailSqlPayload,
+} from "../types/sqailFile";
+import {
+  decryptPayloadSecrets,
+  encodeSqailFile,
+  parseSqailFile,
+  serializeSqailFile,
+} from "../lib/sqail/codec";
+import { useEditorStore } from "./editorStore";
+import { useConnectionStore } from "./connectionStore";
+
+const STORAGE_KEY = "sqail_active_project";
+
+function generateId(): string {
+  return crypto.randomUUID();
+}
+
+function fileNameFromPath(path: string): string {
+  return path.split(/[/\\]/).pop() ?? path;
+}
+
+function loadInitial(): Project | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Project;
+    if (!parsed.id || !Array.isArray(parsed.files)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function persist(project: Project | null): void {
+  if (!project) {
+    localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(project));
+}
+
+interface ProjectState {
+  project: Project | null;
+  newProject: (name?: string) => void;
+  closeProject: () => void;
+  /** Add the active editor tab to the project as a new file and link the tab. */
+  addActiveTabToProject: () => void;
+  /** Open a project file as a tab (focuses an existing linked tab if present). */
+  openFile: (fileId: string) => void;
+  removeFile: (fileId: string) => void;
+  renameFile: (fileId: string, title: string) => void;
+  saveProject: () => Promise<void>;
+  saveProjectAs: () => Promise<void>;
+  openProjectDialog: () => Promise<void>;
+  /** Adopt a decoded project payload (used by fileOps when a .sqail of kind
+   *  "project" is opened). Replaces any active project. */
+  adoptProjectPayload: (
+    data: SqailProjectPayload<ConnectionConfig>,
+    path: string,
+  ) => Promise<void>;
+}
+
+export const useProjectStore = create<ProjectState>((set, get) => ({
+  project: loadInitial(),
+
+  newProject: (name) => {
+    const project: Project = {
+      id: generateId(),
+      name: name ?? "Untitled project",
+      files: [],
+    };
+    set({ project });
+    persist(project);
+  },
+
+  closeProject: () => {
+    const { project } = get();
+    if (!project) return;
+    // Unlink any tabs that were referencing this project's files.
+    const tabs = useEditorStore.getState().tabs;
+    for (const t of tabs) {
+      if (t.projectFileId) {
+        useEditorStore.getState().renameTab(t.id, t.title); // no-op but triggers persist
+      }
+    }
+    set({ project: null });
+    persist(null);
+  },
+
+  addActiveTabToProject: () => {
+    const tab = useEditorStore.getState().getActiveTab();
+    if (!tab) return;
+    const { project } = get();
+    if (!project) return;
+    if (tab.projectFileId) return; // already linked
+
+    const conn = tab.connectionId
+      ? useConnectionStore.getState().connections.find((c) => c.id === tab.connectionId)
+      : undefined;
+
+    const file: ProjectFile = {
+      id: generateId(),
+      kind: tab.kind === "diagram" ? "diagram" : "sql",
+      title: tab.title,
+      sql: tab.kind === "diagram" ? undefined : tab.content,
+      diagram: tab.kind === "diagram" ? tab.diagram : undefined,
+      connection: conn,
+      promptHistory: tab.aiHistory ?? [],
+    };
+    const updated = { ...project, files: [...project.files, file] };
+    set({ project: updated });
+    persist(updated);
+
+    // Link the tab back to this new file.
+    useEditorStore.setState((s) => ({
+      tabs: s.tabs.map((t) => (t.id === tab.id ? { ...t, projectFileId: file.id } : t)),
+    }));
+  },
+
+  openFile: (fileId) => {
+    const { project } = get();
+    if (!project) return;
+    const file = project.files.find((f) => f.id === fileId);
+    if (!file) return;
+
+    // If an open tab already references this file, just focus it.
+    const editor = useEditorStore.getState();
+    const existing = editor.tabs.find((t) => t.projectFileId === fileId);
+    if (existing) {
+      editor.setActiveTab(existing.id);
+      return;
+    }
+
+    // Resolve the file's bundled connection (if any) to a real connection id
+    // in the connection store. We do not silently register — if the user ran
+    // the project through `openProjectDialog`, registration was handled there.
+    const connectionId = resolveBundledConnection(file.connection);
+
+    const descriptor: Omit<EditorTab, "id"> = {
+      title: file.title,
+      content: file.kind === "diagram" ? "" : (file.sql ?? ""),
+      kind: file.kind,
+      diagram: file.diagram,
+      connectionId,
+      aiHistory: file.promptHistory ?? [],
+      promptHistory: lastPrompts(file.promptHistory),
+      projectFileId: file.id,
+    };
+    editor.addRestoredTab(descriptor);
+  },
+
+  removeFile: (fileId) => {
+    const { project } = get();
+    if (!project) return;
+    const updated = {
+      ...project,
+      files: project.files.filter((f) => f.id !== fileId),
+    };
+    set({ project: updated });
+    persist(updated);
+    // Unlink any tab pointing at the removed file.
+    useEditorStore.setState((s) => ({
+      tabs: s.tabs.map((t) =>
+        t.projectFileId === fileId ? { ...t, projectFileId: undefined } : t,
+      ),
+    }));
+  },
+
+  renameFile: (fileId, title) => {
+    const { project } = get();
+    if (!project) return;
+    const updated = {
+      ...project,
+      files: project.files.map((f) => (f.id === fileId ? { ...f, title } : f)),
+    };
+    set({ project: updated });
+    persist(updated);
+  },
+
+  saveProject: async () => {
+    const { project } = get();
+    if (!project) return;
+    if (!project.filePath) {
+      await get().saveProjectAs();
+      return;
+    }
+    await writeProjectToPath(project, project.filePath, set);
+  },
+
+  saveProjectAs: async () => {
+    const { project } = get();
+    if (!project) return;
+    const path = await save({
+      filters: [{ name: "sqail Project", extensions: ["sqail"] }],
+      defaultPath: `${project.name}.sqail`,
+    });
+    if (!path) return;
+    await writeProjectToPath(project, path, set);
+  },
+
+  openProjectDialog: async () => {
+    const path = await open({
+      filters: [{ name: "sqail Project", extensions: ["sqail"] }],
+      multiple: false,
+    });
+    if (!path) return;
+    const raw = await readTextFile(path as string);
+    const file = parseSqailFile(raw);
+
+    let passphrase: string | undefined;
+    if (file.passphraseProtected) {
+      const entered = window.prompt(
+        `"${fileNameFromPath(path as string)}" is passphrase-protected. Enter the passphrase to open it:`,
+      );
+      if (entered == null) return;
+      passphrase = entered;
+    }
+
+    let plain: SqailPlainPayload;
+    try {
+      plain = await decryptPayloadSecrets(file.payload, passphrase);
+    } catch (e) {
+      window.alert(`Failed to open project: ${String(e)}`);
+      return;
+    }
+    if (plain.kind !== "project") {
+      window.alert("Selected .sqail file is not a project bundle.");
+      return;
+    }
+    await get().adoptProjectPayload(plain.data, path as string);
+  },
+
+  adoptProjectPayload: async (data, path) => {
+    // Register any bundled connections the user opts into first, mapping them
+    // so project files that reference them get real connection ids later.
+    const registeredByKey = new Map<string, string>();
+    for (const conn of data.connections ?? []) {
+      const id = await maybeRegisterConnection(conn);
+      if (id) registeredByKey.set(connectionKey(conn), id);
+    }
+    // For each file, also offer to register its own connection (de-duped).
+    for (const f of data.files) {
+      const conn = f.payload.connection;
+      if (!conn) continue;
+      const key = connectionKey(conn);
+      if (registeredByKey.has(key)) continue;
+      const id = await maybeRegisterConnection(conn);
+      if (id) registeredByKey.set(key, id);
+    }
+
+    const files: ProjectFile[] = data.files.map((f): ProjectFile => {
+      if (f.kind === "diagram") {
+        const p = f.payload as SqailDiagramPayload<ConnectionConfig>;
+        return {
+          id: generateId(),
+          kind: "diagram",
+          title: p.title,
+          diagram: p.diagram,
+          connection: p.connection,
+          promptHistory: p.promptHistory ?? [],
+        };
+      }
+      const p = f.payload as SqailSqlPayload<ConnectionConfig>;
+      return {
+        id: generateId(),
+        kind: "sql",
+        title: p.title,
+        sql: p.sql,
+        connection: p.connection,
+        promptHistory: p.promptHistory ?? [],
+      };
+    });
+
+    const project: Project = {
+      id: generateId(),
+      name: data.name,
+      files,
+      filePath: path,
+    };
+    set({ project });
+    persist(project);
+  },
+}));
+
+// ---------------------------------------------------------------------------
+
+async function writeProjectToPath(
+  project: Project,
+  path: string,
+  set: (partial: Partial<ProjectState>) => void,
+): Promise<void> {
+  // Snapshot any open tabs linked to project files back into the files array.
+  const tabs = useEditorStore.getState().tabs;
+  const connections = useConnectionStore.getState().connections;
+
+  const snapshotted: ProjectFile[] = project.files.map((f) => {
+    const linked = tabs.find((t) => t.projectFileId === f.id);
+    if (!linked) return f;
+    const conn = linked.connectionId
+      ? connections.find((c) => c.id === linked.connectionId)
+      : f.connection;
+    return {
+      ...f,
+      title: linked.title || f.title,
+      sql: linked.kind === "diagram" ? undefined : linked.content,
+      diagram: linked.kind === "diagram" ? linked.diagram : undefined,
+      connection: conn,
+      promptHistory: linked.aiHistory ?? f.promptHistory,
+    };
+  });
+
+  const payload: SqailPlainPayload = {
+    kind: "project",
+    data: {
+      name: project.name,
+      files: snapshotted.map((f): SqailProjectFile<ConnectionConfig> => {
+        if (f.kind === "diagram") {
+          const p: SqailDiagramPayload<ConnectionConfig> = {
+            title: f.title,
+            diagram: f.diagram ?? ({} as never),
+            connection: f.connection,
+            promptHistory: f.promptHistory,
+          };
+          return { kind: "diagram", payload: p };
+        }
+        const p: SqailSqlPayload<ConnectionConfig> = {
+          title: f.title,
+          sql: f.sql ?? "",
+          connection: f.connection,
+          promptHistory: f.promptHistory,
+        };
+        return { kind: "sql", payload: p };
+      }),
+    },
+  };
+
+  const file = await encodeSqailFile(payload);
+  await writeTextFile(path, serializeSqailFile(file));
+
+  const updated: Project = { ...project, files: snapshotted, filePath: path };
+  set({ project: updated });
+  persist(updated);
+}
+
+function connectionKey(c: ConnectionConfig): string {
+  return `${c.driver}|${c.host}|${c.port}|${c.database}|${c.user}|${c.filePath}`;
+}
+
+function resolveBundledConnection(
+  bundled: ConnectionConfig | undefined,
+): string | undefined {
+  if (!bundled) return undefined;
+  const { connections } = useConnectionStore.getState();
+  const match = connections.find((c) => connectionKey(c) === connectionKey(bundled));
+  return match?.id;
+}
+
+async function maybeRegisterConnection(
+  bundled: ConnectionConfig,
+): Promise<string | undefined> {
+  const { connections } = useConnectionStore.getState();
+  const existing = connections.find(
+    (c) => connectionKey(c) === connectionKey(bundled),
+  );
+  if (existing) return existing.id;
+  const label =
+    bundled.name ||
+    `${bundled.driver}://${bundled.user ? bundled.user + "@" : ""}${bundled.host}${bundled.port ? ":" + bundled.port : ""}${bundled.database ? "/" + bundled.database : ""}`;
+  const ok = window.confirm(
+    `This project bundles a database connection:\n\n  ${label}\n\nAdd it to your saved connections? Credentials will be stored locally.`,
+  );
+  if (!ok) return undefined;
+  const toCreate: ConnectionConfig = { ...bundled, id: "" };
+  const created = await invoke<ConnectionConfig>("create_connection", { config: toCreate });
+  await useConnectionStore.getState().loadConnections();
+  return created.id;
+}
+
+function lastPrompts(
+  entries: { prompt?: string }[] | undefined,
+): string[] {
+  if (!entries || entries.length === 0) return [];
+  const prompts = entries
+    .map((e) => e.prompt)
+    .filter((p): p is string => typeof p === "string" && p.length > 0);
+  return prompts.slice(-10);
+}

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,4 +1,5 @@
 import type { DiagramState } from "./diagram";
+import type { SqailPromptEntry } from "./sqailFile";
 
 export type EditorTabKind = "sql" | "diagram";
 
@@ -12,4 +13,13 @@ export interface EditorTab {
   pinned?: boolean;
   kind?: EditorTabKind; // default "sql"
   diagram?: DiagramState; // present when kind === "diagram"
+  /** Last ~10 prompts typed into the AI palette while this tab was active.
+   *  Powers ArrowUp/ArrowDown navigation in the palette. */
+  promptHistory?: string[];
+  /** Rich per-file AI exchanges (prompt + response). Bundled into `.sqail`
+   *  when the tab is saved in that format. */
+  aiHistory?: SqailPromptEntry[];
+  /** When set, this tab is the working copy of a file inside the active
+   *  project. Project save snapshots the tab's state back into that file. */
+  projectFileId?: string;
 }

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,29 @@
+import type { ConnectionConfig } from "./connection";
+import type { DiagramState } from "./diagram";
+import type { SqailPromptEntry } from "./sqailFile";
+
+export type ProjectFileKind = "sql" | "diagram";
+
+/**
+ * A single file inside a project. Holds the last-snapshotted state; while a
+ * tab is open and linked to this file (via `EditorTab.projectFileId`), the
+ * tab is authoritative until the project is saved (which snapshots the tabs
+ * back into their files).
+ */
+export interface ProjectFile {
+  id: string;
+  kind: ProjectFileKind;
+  title: string;
+  sql?: string;
+  diagram?: DiagramState;
+  connection?: ConnectionConfig;
+  promptHistory?: SqailPromptEntry[];
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  files: ProjectFile[];
+  /** Filesystem path the project was last saved to / opened from. */
+  filePath?: string;
+}

--- a/src/types/sqailFile.ts
+++ b/src/types/sqailFile.ts
@@ -1,0 +1,98 @@
+import type { ConnectionConfig } from "./connection";
+import type { DiagramState } from "./diagram";
+
+/**
+ * `.sqail` file format (v1).
+ *
+ * Human-readable JSON. Sensitive strings (connection password, API tokens)
+ * are replaced with a {@link EncryptedField} envelope produced by the Rust
+ * `sqail_encrypt_secret` command.
+ *
+ * Three top-level kinds:
+ *  - `sql`     — a single SQL editor tab's content + optional connection + per-tab AI prompt history
+ *  - `diagram` — a single diagram tab's state + optional connection + per-tab AI prompt history
+ *  - `project` — a bundle of files (SQL + diagram payloads) + shared connections
+ */
+
+export const SQAIL_FILE_VERSION = 1;
+
+/** Sentinel for an encrypted string field inside the JSON payload. */
+export interface EncryptedField {
+  $enc: true;
+  alg: string; // e.g. "AES-256-GCM/machine" or "AES-256-GCM/argon2id"
+  nonce: string; // base64
+  ct: string; // base64 ciphertext
+  salt?: string; // base64, passphrase mode only
+}
+
+/** One entry in a per-file AI prompt history. Separate from the global DB-backed history. */
+export interface SqailPromptEntry {
+  timestamp: string;
+  flow: string;
+  prompt: string;
+  response: string;
+}
+
+/** A connection as stored inside a `.sqail` — password is an encrypted envelope. */
+export interface SqailConnection extends Omit<ConnectionConfig, "password" | "dbserviceApiKey"> {
+  password: EncryptedField | "";
+  dbserviceApiKey: EncryptedField | "";
+}
+
+/**
+ * Payloads are parameterised over the connection representation:
+ *  - `ConnectionConfig` — plain, used when building a file in-memory before encoding.
+ *  - `SqailConnection`  — encrypted envelope form, used in the serialised file.
+ */
+
+export interface SqailSqlPayload<C = SqailConnection> {
+  title: string;
+  sql: string;
+  connection?: C;
+  promptHistory?: SqailPromptEntry[];
+}
+
+export interface SqailDiagramPayload<C = SqailConnection> {
+  title: string;
+  diagram: DiagramState;
+  connection?: C;
+  promptHistory?: SqailPromptEntry[];
+}
+
+export interface SqailProjectFile<C = SqailConnection> {
+  kind: "sql" | "diagram";
+  payload: SqailSqlPayload<C> | SqailDiagramPayload<C>;
+}
+
+export interface SqailProjectPayload<C = SqailConnection> {
+  name: string;
+  files: SqailProjectFile<C>[];
+  connections?: C[];
+}
+
+export type SqailPayload<C = SqailConnection> =
+  | { kind: "sql"; data: SqailSqlPayload<C> }
+  | { kind: "diagram"; data: SqailDiagramPayload<C> }
+  | { kind: "project"; data: SqailProjectPayload<C> };
+
+/** Pre-encryption payload supplied by callers. Re-exported for convenience. */
+export type SqailPlainPayload = SqailPayload<ConnectionConfig>;
+
+export interface SqailFile {
+  /** Magic identifier — lets the codec reject unrelated `.json` files. */
+  magic: "sqail";
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  /** `true` if the file contains any encrypted fields that need the machine key or a passphrase. */
+  encrypted: boolean;
+  /** `true` if decryption requires the user to provide a passphrase. */
+  passphraseProtected: boolean;
+  payload: SqailPayload;
+}
+
+export function isEncryptedField(v: unknown): v is EncryptedField {
+  return (
+    typeof v === "object" && v !== null && (v as { $enc?: unknown }).$enc === true
+  );
+}


### PR DESCRIPTION
## Summary
- New `.sqail` JSON file format with AES-256-GCM encryption (machine key or user passphrase via Argon2id)
- Save/load SQL tabs and diagram tabs as `.sqail` (bundles content, optional encrypted connection, per-tab AI history)
- Project panel in sidebar: bundle multiple SQL/diagram files plus shared connections into a `.sqail` project
- Per-tab AI prompt history (palette recency lives on the tab; DB-backed global history unchanged)
- Rust: new `crypto` module + `sqail_encrypt_secret` / `sqail_decrypt_secret` Tauri commands

## Test plan
- [ ] Save a SQL tab as `.sql` — content matches editor verbatim
- [ ] Save a SQL tab as `.sqail` with bundled connection — re-open prompts before registering credentials
- [ ] Save a diagram tab as `.sqail` — round-trips state on reopen
- [ ] Create a project, add tabs, save and re-open — all tabs restore
- [ ] Encrypt with passphrase — wrong passphrase rejected; correct passphrase recovers
- [ ] `cargo check` clean / `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)