### PR TITLE
fix(mssql): add Encryption option to connect to older SQL Servers (#51)

### DIFF
--- a/src-tauri/src/db/connections.rs
+++ b/src-tauri/src/db/connections.rs
@@ -20,6 +20,22 @@ pub enum MssqlAuthMethod {
     EntraId,
 }
 
+/// Connection encryption level for MSSQL (tiberius).
+/// Maps to `tiberius::EncryptionLevel`. Defaults to `Required` to preserve
+/// existing behavior; `Off` (no TLS at all) is the workaround for older
+/// servers whose only TLS protocols/ciphers modern Windows SChannel refuses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MssqlEncryption {
+    /// Encrypt everything; fail if the server can't. (tiberius `Required`)
+    #[default]
+    Required,
+    /// Encrypt only the login handshake. (tiberius `Off`)
+    LoginOnly,
+    /// No encryption at all — skip the TLS handshake. (tiberius `NotSupported`)
+    Off,
+}
+
 impl std::fmt::Display for Driver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -59,6 +75,8 @@ pub struct ConnectionConfig {
     pub trust_server_certificate: bool,
     #[serde(default)]
     pub mssql_auth_method: MssqlAuthMethod,
+    #[serde(default)]
+    pub mssql_encryption: MssqlEncryption,
     #[serde(default)]
     pub tenant_id: String,
     #[serde(default)]
@@ -136,6 +154,12 @@ impl ConnectionConfig {
                 }
             }
         }
+
+        config.encryption(match self.mssql_encryption {
+            MssqlEncryption::Required => tiberius::EncryptionLevel::Required,
+            MssqlEncryption::LoginOnly => tiberius::EncryptionLevel::Off,
+            MssqlEncryption::Off => tiberius::EncryptionLevel::NotSupported,
+        });
 
         if self.trust_server_certificate {
             config.trust_cert();

--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -7,12 +7,14 @@ import {
   type ConnectionConfig,
   type Driver,
   type MssqlAuthMethod,
+  type MssqlEncryption,
   defaultConnection,
   defaultPort,
   parseConnectionString,
   toConnectionString,
   DRIVER_LABELS,
   MSSQL_AUTH_LABELS,
+  MSSQL_ENCRYPTION_LABELS,
 } from "../types/connection";
 
 interface ConnectionFormProps {
@@ -31,7 +33,11 @@ interface DeviceCodeInfo {
 }
 
 export default function ConnectionForm({ initial, onClose }: ConnectionFormProps) {
-  const [form, setForm] = useState<ConnectionConfig>(initial ?? defaultConnection());
+  // Merge over defaults so connections saved before a field existed (e.g. mssqlEncryption)
+  // still yield a fully-populated, controlled form.
+  const [form, setForm] = useState<ConnectionConfig>(
+    initial ? { ...defaultConnection(initial.driver), ...initial } : defaultConnection(),
+  );
   const [testStatus, setTestStatus] = useState<TestStatus>("idle");
   const [testMessage, setTestMessage] = useState("");
   const [saving, setSaving] = useState(false);
@@ -384,6 +390,23 @@ export default function ConnectionForm({ initial, onClose }: ConnectionFormProps
                     />
                     <span className="text-muted-foreground">Trust Server Certificate</span>
                   </label>
+                  <Field label="Encryption">
+                    <select
+                      value={form.mssqlEncryption}
+                      onChange={(e) => set("mssqlEncryption", e.target.value as MssqlEncryption)}
+                      className="input"
+                    >
+                      {(Object.keys(MSSQL_ENCRYPTION_LABELS) as MssqlEncryption[]).map((e) => (
+                        <option key={e} value={e}>
+                          {MSSQL_ENCRYPTION_LABELS[e]}
+                        </option>
+                      ))}
+                    </select>
+                    <p className="mt-1 text-[11px] text-muted-foreground">
+                      Set to <strong>Off</strong> for older SQL Servers that fail with a TLS handshake or
+                      “no common algorithm” error.
+                    </p>
+                  </Field>
                 </>
               )}
               {form.driver === "mssql" && form.mssqlAuthMethod === "entra_id" && (

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -1,5 +1,6 @@
 export type Driver = "postgres" | "mysql" | "sqlite" | "mssql" | "dbservice" | "surrealdb";
 export type MssqlAuthMethod = "sql_server" | "windows" | "entra_id";
+export type MssqlEncryption = "required" | "login_only" | "off";
 
 export interface ConnectionConfig {
   id: string;
@@ -15,6 +16,7 @@ export interface ConnectionConfig {
   integratedSecurity: boolean;
   trustServerCertificate: boolean;
   mssqlAuthMethod: MssqlAuthMethod;
+  mssqlEncryption: MssqlEncryption;
   tenantId: string;
   azureClientId: string;
   color: string;
@@ -58,6 +60,7 @@ export function defaultConnection(driver: Driver = "postgres"): ConnectionConfig
     integratedSecurity: false,
     trustServerCertificate: false,
     mssqlAuthMethod: "sql_server",
+    mssqlEncryption: "required",
     tenantId: "",
     azureClientId: "",
     color: "",
@@ -81,6 +84,12 @@ export const MSSQL_AUTH_LABELS: Record<MssqlAuthMethod, string> = {
   sql_server: "SQL Server",
   windows: "Windows",
   entra_id: "Entra ID",
+};
+
+export const MSSQL_ENCRYPTION_LABELS: Record<MssqlEncryption, string> = {
+  required: "Required",
+  login_only: "Login only",
+  off: "Off",
 };
 
 /** Parse a connection string into a partial ConnectionConfig. */
@@ -171,6 +180,10 @@ export function parseConnectionString(raw: string): Partial<ConnectionConfig> & 
       trustServerCertificate: (kv.get("trustservercertificate") ?? "").toLowerCase() === "true",
       integratedSecurity: (kv.get("integrated security") ?? "").toLowerCase() === "true"
         || (kv.get("trusted_connection") ?? "").toLowerCase() === "true",
+      // Encrypt=false/optional/no/0 → no encryption (older-server workaround); anything else keeps the default.
+      ...(["false", "optional", "no", "0"].includes((kv.get("encrypt") ?? "").toLowerCase())
+        ? { mssqlEncryption: "off" as MssqlEncryption }
+        : {}),
     };
   }
 
@@ -211,6 +224,7 @@ export function toConnectionString(c: ConnectionConfig): string {
         if (c.password) parts.push(`Password=${c.password}`);
       }
       if (c.trustServerCertificate) parts.push("TrustServerCertificate=true");
+      if (c.mssqlEncryption === "off") parts.push("Encrypt=false");
       return parts.join(";") + ";";
     }
   }


### PR DESCRIPTION
## Summary

Fixes #51 — `MSSQL connection failed: Error forming TLS connection: The client and server cannot communicate, because they do not possess a common algorithm. (os error -2146893007)` when connecting to an older SQL Server.

This is a direct follow-up to #49. That fix switched tiberius from rustls to **native-tls**, which got past rustls'' outright refusal — but now **SChannel** (Windows'' TLS stack) does the negotiation and returns `SEC_E_ALGORITHM_MISMATCH` (`0x80090331`). Modern Windows disables the legacy TLS 1.0/1.1 protocols and weak ciphers (3DES/RC4, RSA key exchange) that these old servers are the *only* ones to offer, so there is no common algorithm.

The only in-app remedy is to let the connection **skip TLS entirely**, which is what `Encrypt=false` does in SSMS/.NET.

## Change

Expose a per-connection **Encryption** setting mapping to `tiberius::EncryptionLevel`:

| UI label   | tiberius `EncryptionLevel` | Behavior |
|------------|----------------------------|----------|
| Required (default) | `Required`     | Encrypt everything; current behavior |
| Login only | `Off`                      | Encrypt only the login handshake |
| Off        | `NotSupported`             | No TLS handshake at all — **fixes #51** |

- **Backend** (`src-tauri/src/db/connections.rs`): new `MssqlEncryption` enum + `mssql_encryption` field, applied via `config.encryption(...)` in `tiberius_config()`. Defaults to `Required`, so existing connections are unchanged.
- **Frontend**: type, default, labels, an **Encryption** dropdown in the MSSQL connection form (with a hint that `Off` is for older servers failing on TLS), and `Encrypt=true/false` round-tripping in the connection-string parser/builder.
- The form now merges saved connections over defaults, so rows saved before this field existed render a controlled select.

## Caveat

`Off` only works if the server is **not** set to *Force Encryption*. If it is, the only path is re-enabling legacy TLS in Windows SChannel (an OS/registry change, out of scope for the app).

## Testing
- `tsc --noEmit`, `eslint`, `cargo clippy --lib`, and `vite build` all pass (only the pre-existing TanStack-Table and chunk-size advisories remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)